### PR TITLE
chore: extend fee sharing interface to be action-specific

### DIFF
--- a/src/FeeCalculator.sol
+++ b/src/FeeCalculator.sol
@@ -151,12 +151,12 @@ contract FeeCalculator is IFeeCalculator, Ownable {
         require(feeAmount > 0, "Fee must be greater than 0");
     }
 
-    /// @notice Calculates the total fee among the recipients according to their shares.
+    /// @notice Calculates the fee shares and recipients based on the total fee.
     /// @param totalFee The total fee to be distributed.
     /// @return recipients The addresses of the fee recipients.
     /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
-    function calculateFeeAmongShares(uint256 totalFee)
-        external
+    function calculateFeeShares(uint256 totalFee)
+        internal
         view
         returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens)
     {
@@ -191,6 +191,30 @@ contract FeeCalculator is IFeeCalculator, Ownable {
 
         require(feeAmount <= redemptionAmount, "Fee must be lower or equal to redemption amount");
         require(feeAmount > 0, "Fee must be greater than 0");
+    }
+
+    /// @notice Calculates the fee shares and recipients for a deposit based on the total fee.
+    /// @param totalFee The total fee to be shared.
+    /// @return recipients The addresses of the fee recipients.
+    /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
+    function calculateDepositFeeShares(uint256 totalFee)
+        external
+        view
+        returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens)
+    {
+        return calculateFeeShares(totalFee);
+    }
+
+    /// @notice Calculates the fee shares and recipients for a redemption based on the total fee.
+    /// @param totalFee The total fee to be shared.
+    /// @return recipients The addresses of the fee recipients.
+    /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
+    function calculateRedemptionFeeShares(uint256 totalFee)
+        external
+        view
+        returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens)
+    {
+        return calculateFeeShares(totalFee);
     }
 
     /// @notice Gets the balance of the TCO2 token in a given pool.

--- a/src/interfaces/IFeeCalculator.sol
+++ b/src/interfaces/IFeeCalculator.sol
@@ -31,11 +31,20 @@ interface IFeeCalculator {
         view
         returns (uint256 feeAmount);
 
-    /// @notice Calculates the total fee among the recipients according to their shares.
-    /// @param totalFee The total fee to be distributed.
+    /// @notice Calculates the fee shares and recipients for a deposit based on the total fee.
+    /// @param totalFee The total fee to be shared.
     /// @return recipients The addresses of the fee recipients.
     /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
-    function calculateFeeAmongShares(uint256 totalFee)
+    function calculateDepositFeeShares(uint256 totalFee)
+        external
+        view
+        returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens);
+
+    /// @notice Calculates the fee shares and recipients for a redemption based on the total fee.
+    /// @param totalFee The total fee to be shared.
+    /// @return recipients The addresses of the fee recipients.
+    /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
+    function calculateRedemptionFeeShares(uint256 totalFee)
         external
         view
         returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens);

--- a/test/FeeCalculator.fuzzy.t.sol
+++ b/test/FeeCalculator.fuzzy.t.sol
@@ -277,7 +277,7 @@ contract FeeCalculatorTestFuzzy is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory gotRecipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory gotRecipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(gotRecipients.length, recipients.length);

--- a/test/FeeCalculator.t.sol
+++ b/test/FeeCalculator.t.sol
@@ -73,7 +73,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -92,7 +92,7 @@ contract FeeCalculatorTest is Test {
         // Act
         uint256 feeAmount =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -111,7 +111,7 @@ contract FeeCalculatorTest is Test {
         // Act
         uint256 feeAmount =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -132,7 +132,7 @@ contract FeeCalculatorTest is Test {
         // Act
         uint256 feeAmount =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -160,7 +160,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -191,7 +191,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -212,7 +212,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -261,7 +261,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -279,7 +279,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -316,7 +316,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -362,7 +362,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -389,7 +389,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -481,7 +481,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -499,7 +499,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -532,7 +532,7 @@ contract FeeCalculatorTest is Test {
         // Act
         uint256 feeAmount =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -550,7 +550,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -568,7 +568,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -586,7 +586,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -605,7 +605,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -623,7 +623,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -766,7 +766,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(fees[0], 9718378209069523938 / 2);
@@ -781,7 +781,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(fees[0], 1299819671838098442);
@@ -796,7 +796,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(fees[0], 67 * 1e18);
@@ -811,7 +811,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100e18);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(fees[0], 3778028623870480400);
@@ -826,7 +826,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100e18);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(fees[0], 2303907724666580660);
@@ -841,7 +841,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         assertEq(fees[0], 83 * 1e18);
     }
@@ -858,7 +858,7 @@ contract FeeCalculatorTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
-        (, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
 
         // Assert
         assertEq(fees[0], depositAmount * 91 / 100);

--- a/test/FeeCalculatorLaunchParams.t.sol
+++ b/test/FeeCalculatorLaunchParams.t.sol
@@ -42,7 +42,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -71,7 +71,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -102,7 +102,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -123,7 +123,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -173,7 +173,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -192,7 +192,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -230,7 +230,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -277,7 +277,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -305,7 +305,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -354,7 +354,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -386,7 +386,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -418,7 +418,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateFeeAmongShares(feeAmount);
+        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
 
         // Assert
         assertEq(recipients[0], feeRecipient);


### PR DESCRIPTION
This change future-proofs the interface between the fee module and the pool in case other modules in the future may need to apply different fee sharing logic for deposits vs redemptions.