### PR TITLE
[LILA-6102] use new TCO2 supply method from Pool

### DIFF
--- a/src/FeeCalculator.sol
+++ b/src/FeeCalculator.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import {SD59x18, sd, intoUint256} from "@prb/math/src/SD59x18.sol";
 
 import "./interfaces/IFeeCalculator.sol";
+import "./interfaces/IPool.sol";
 
 /// @title FeeCalculator
 /// @author Neutral Labs Inc.
@@ -230,7 +231,7 @@ contract FeeCalculator is IFeeCalculator, Ownable {
     /// @param pool The address of the pool.
     /// @return The total supply of the pool.
     function getTotalSupply(address pool) private view returns (uint256) {
-        uint256 totalSupply = IERC20(pool).totalSupply();
+        uint256 totalSupply = IPool(pool).totalTCO2Supply();
         return totalSupply;
     }
 

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2023 Neutral Labs Inc.
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+/// @title IPool
+/// @author Neutral Labs Inc.
+/// @notice This interface defines methods exposed by the Pool
+interface IPool {
+    /// @notice Exposes the total TCO2 supply, tracked as the aggregation of deposit,
+    /// redemmption and bridge actions
+    /// @return supply Current supply
+    function totalTCO2Supply() external view returns (uint256 supply);
+}

--- a/test/TestUtilities.sol
+++ b/test/TestUtilities.sol
@@ -24,6 +24,10 @@ contract MockPool is IERC20 {
         return _totalSupply;
     }
 
+    function totalTCO2Supply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
     function setTotalSupply(uint256 ts) public {
         _totalSupply = ts;
     }


### PR DESCRIPTION
The Pool total supply is now read from the new `totalTCO2supply` method (more accurate).

See https://github.com/ToucanProtocol/tokenizer/pull/3194