### PR TITLE
[LILA-6145] Consolidate interface functions

### DIFF
--- a/src/interfaces/IFeeCalculator.sol
+++ b/src/interfaces/IFeeCalculator.sol
@@ -5,6 +5,11 @@
 // If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
 pragma solidity ^0.8.13;
 
+struct FeeDistribution {
+    address[] recipients;
+    uint256[] shares;
+}
+
 /// @title IFeeCalculator
 /// @author Neutral Labs Inc.
 /// @notice This interface defines methods for calculating fees.
@@ -13,39 +18,21 @@ interface IFeeCalculator {
     /// @param tco2 The address of the TCO2 token.
     /// @param pool The address of the pool.
     /// @param depositAmount The amount to be deposited.
-    /// @return feeAmount The fee to be charged in pool
-    /// tokens for this deposit.
+    /// @return feeDistribution How the fee is meant to be
+    /// distributed among the fee recipients.
     function calculateDepositFees(address tco2, address pool, uint256 depositAmount)
         external
         view
-        returns (uint256 feeAmount);
+        returns (FeeDistribution memory feeDistribution);
 
     /// @notice Calculates the redemption fees for a given amount.
     /// @param tco2 The address of the TCO2 token.
     /// @param pool The address of the pool.
     /// @param redemptionAmount The amount to be redeemed.
-    /// @return feeAmount The fee to be charged in pool
-    /// tokens for this redemption.
+    /// @return feeDistribution How the fee is meant to be
+    /// distributed among the fee recipients.
     function calculateRedemptionFees(address tco2, address pool, uint256 redemptionAmount)
         external
         view
-        returns (uint256 feeAmount);
-
-    /// @notice Calculates the fee shares and recipients for a deposit based on the total fee.
-    /// @param totalFee The total fee to be shared.
-    /// @return recipients The addresses of the fee recipients.
-    /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
-    function calculateDepositFeeShares(uint256 totalFee)
-        external
-        view
-        returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens);
-
-    /// @notice Calculates the fee shares and recipients for a redemption based on the total fee.
-    /// @param totalFee The total fee to be shared.
-    /// @return recipients The addresses of the fee recipients.
-    /// @return feesDenominatedInPoolTokens The amount of fees each recipient should receive.
-    function calculateRedemptionFeeShares(uint256 totalFee)
-        external
-        view
-        returns (address[] memory recipients, uint256[] memory feesDenominatedInPoolTokens);
+        returns (FeeDistribution memory feeDistribution);
 }

--- a/test/FeeCalculator.t.sol
+++ b/test/FeeCalculator.t.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.13;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {FeeCalculator} from "../src/FeeCalculator.sol";
+import {FeeDistribution} from "../src/interfaces/IFeeCalculator.sol";
 import {SD59x18, sd, intoUint256 as sdIntoUint256} from "@prb/math/src/SD59x18.sol";
 import {UD60x18, ud, intoUint256} from "@prb/math/src/UD60x18.sol";
 import "./TestUtilities.sol";
@@ -72,10 +73,13 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
+        assertEq(feeDistribution.recipients.length, feeDistribution.shares.length, "array length mismatch");
         assertEq(recipients[0], feeRecipient);
         assertEq(fees[0], 9718378209069523938);
     }
@@ -90,11 +94,13 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
 
         // Act
-        uint256 feeAmount =
+        FeeDistribution memory feeDistribution =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
+        assertEq(feeDistribution.recipients.length, feeDistribution.shares.length, "array length mismatch");
         assertEq(recipients[0], feeRecipient);
         assertEq(fees[0], 2833521467902860250);
     }
@@ -109,9 +115,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1 * 1e18);
 
         // Act
-        uint256 feeAmount =
+        FeeDistribution memory feeDistribution =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -130,9 +137,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e6 * 1e18);
 
         // Act
-        uint256 feeAmount =
+        FeeDistribution memory feeDistribution =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -159,8 +167,10 @@ contract FeeCalculatorTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -190,8 +200,10 @@ contract FeeCalculatorTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -211,8 +223,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 15462 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -260,8 +274,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -278,8 +294,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -315,8 +333,10 @@ contract FeeCalculatorTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -361,8 +381,10 @@ contract FeeCalculatorTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -388,8 +410,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e6 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -480,8 +504,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 0);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -498,8 +524,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 0);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -530,9 +558,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1000);
 
         // Act
-        uint256 feeAmount =
+        FeeDistribution memory feeDistribution =
             feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), redemptionAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -549,8 +578,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1000);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -567,8 +598,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 999);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -585,8 +618,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 0);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -604,8 +639,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), supply - 1);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -622,8 +659,10 @@ contract FeeCalculatorTest is Test {
         mockToken.setTokenBalance(address(mockPool), 55661911070827884041095553095);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -765,8 +804,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setDepositFeeScale(0.09 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(fees[0], 9718378209069523938 / 2);
@@ -780,8 +820,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setDepositFeeRatioScale(0.2 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(fees[0], 1299819671838098442);
@@ -795,8 +836,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setSingleAssetDepositRelativeFee(0.67 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), 100 * 1e18);
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(fees[0], 67 * 1e18);
@@ -810,8 +852,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setRedemptionFeeScale(0.4 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100e18);
-        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100e18);
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(fees[0], 3778028623870480400);
@@ -825,8 +868,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setRedemptionFeeShift(0.5 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100e18);
-        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100e18);
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(fees[0], 2303907724666580660);
@@ -840,8 +884,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setSingleAssetRedemptionRelativeFee(0.83 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100 * 1e18);
-        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), 100 * 1e18);
+        uint256[] memory fees = feeDistribution.shares;
 
         assertEq(fees[0], 83 * 1e18);
     }
@@ -857,8 +902,9 @@ contract FeeCalculatorTest is Test {
         feeCalculator.setDustAssetRedemptionRelativeFee(0.91 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
-        (, uint256[] memory fees) = feeCalculator.calculateRedemptionFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateRedemptionFees(address(mockToken), address(mockPool), depositAmount);
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(fees[0], depositAmount * 91 / 100);

--- a/test/FeeCalculatorLaunchParams.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParams.fuzzy.t.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.13;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {FeeCalculator} from "../src/FeeCalculator.sol";
+import {FeeDistribution} from "../src/interfaces/IFeeCalculator.sol";
 import "./TestUtilities.sol";
 
 contract FeeCalculatorLaunchParamsTestFuzzy is Test {
@@ -116,9 +117,9 @@ contract FeeCalculatorLaunchParamsTestFuzzy is Test {
 
         // Act
         try feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount) returns (
-            uint256 feeAmount
+            FeeDistribution memory feeDistribution
         ) {
-            oneTimeFee = feeAmount;
+            oneTimeFee = feeDistribution.shares.sumOf();
         } catch Error(string memory reason) {
             oneTimeDepositFailed = true;
             assertTrue(
@@ -137,9 +138,9 @@ contract FeeCalculatorLaunchParamsTestFuzzy is Test {
             uint256 deposit = equalDeposit + (i == 0 ? restDeposit : 0);
 
             try feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), deposit) returns (
-                uint256 feeAmount
+                FeeDistribution memory feeDistribution
             ) {
-                feeFromDividedDeposits += feeAmount;
+                feeFromDividedDeposits += feeDistribution.shares.sumOf();
                 total += deposit;
                 current += deposit;
                 mockPool.setTotalSupply(total);

--- a/test/FeeCalculatorLaunchParams.t.sol
+++ b/test/FeeCalculatorLaunchParams.t.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.13;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {FeeCalculator} from "../src/FeeCalculator.sol";
+import {FeeDistribution} from "../src/interfaces/IFeeCalculator.sol";
 import "./TestUtilities.sol";
 
 contract FeeCalculatorLaunchParamsTest is Test {
@@ -41,8 +42,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -70,8 +73,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -101,8 +106,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -122,8 +129,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 15462 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -172,8 +181,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -191,8 +202,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -229,8 +242,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -276,8 +291,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         feeCalculator.feeSetup(_recipients, _feeShares);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient1);
@@ -304,8 +321,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1e6 * 1e18);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -353,8 +372,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 0);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -385,8 +406,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 1000);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);
@@ -417,8 +440,10 @@ contract FeeCalculatorLaunchParamsTest is Test {
         mockToken.setTokenBalance(address(mockPool), 0);
 
         // Act
-        uint256 feeAmount = feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
-        (address[] memory recipients, uint256[] memory fees) = feeCalculator.calculateDepositFeeShares(feeAmount);
+        FeeDistribution memory feeDistribution =
+            feeCalculator.calculateDepositFees(address(mockToken), address(mockPool), depositAmount);
+        address[] memory recipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
 
         // Assert
         assertEq(recipients[0], feeRecipient);


### PR DESCRIPTION
Consolidate the fee module interface functions
into a single function per action as originally
developed.

This consolidation should:
* make it easier for pools to integrate with the
fee module since there is only a single function
per action to use
* make the interface future-proof in case fee
modules in the future are determining fee recipients
based on the TCO2 that is deposited to or redeemed
from the pool
* make the fee calculation more performant since
there is only a single CALL to the fee module
instead of two per action

This change reverts https://github.com/neutral-protocol/dynamic-fee-pools/commit/99f19a43e8fb0f8a2b2a94dcf8ea67f6227f4bb0