### PR TITLE
Use project composition to calculate fees

### DIFF
--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -10,7 +10,14 @@ pragma solidity ^0.8.13;
 /// @notice This interface defines methods exposed by the Pool
 interface IPool {
     /// @notice Exposes the total TCO2 supply, tracked as the aggregation of deposit,
-    /// redemmption and bridge actions
+    /// redemption and bridge actions
     /// @return supply Current supply
     function totalTCO2Supply() external view returns (uint256 supply);
+
+    /// @notice Exposes the total TCO2 supply of a project in a pool,
+    /// tracked as the aggregation of deposit, redemmption and bridge actions
+    /// @param projectTokenId The token id of the project as it's tracked
+    /// in the CarbonProjects contract
+    /// @return supply Current supply of a project in the pool
+    function totalPerProjectTCO2Supply(uint256 projectTokenId) external view returns (uint256 supply);
 }

--- a/src/interfaces/ITCO2.sol
+++ b/src/interfaces/ITCO2.sol
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 Neutral Labs Inc.
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+struct VintageData {
+    /// @dev A human-readable string which differentiates this from other vintages in
+    /// the same project, and helps build the corresponding TCO2 name and symbol.
+    string name;
+    uint64 startTime; // UNIX timestamp
+    uint64 endTime; // UNIX timestamp
+    uint256 projectTokenId;
+    uint64 totalVintageQuantity;
+    bool isCorsiaCompliant;
+    bool isCCPcompliant;
+    string coBenefits;
+    string correspAdjustment;
+    string additionalCertification;
+    string uri;
+    string registry;
+}
+
+/// @title ITCO2
+/// @notice This interface defines methods exposed by the TCO2
+interface ITCO2 {
+    /// @notice Get the vintage data for the TCO2
+    /// @return vintageData Vintage data of the TCO2
+    function getVintageData() external view returns (VintageData memory vintageData);
+}

--- a/test/FeeCalculator.fuzzy.t.sol
+++ b/test/FeeCalculator.fuzzy.t.sol
@@ -45,7 +45,7 @@ contract FeeCalculatorTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e12 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e9 * 1e18);
+        mockPool.setProjectSupply(1, 1e9 * 1e18);
 
         vm.expectRevert("Fee must be greater than 0");
         feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
@@ -65,7 +65,7 @@ contract FeeCalculatorTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockToken.setTokenBalance(address(mockPool), current);
+        mockPool.setProjectSupply(1, current);
 
         // Act
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount) {}
@@ -114,7 +114,7 @@ contract FeeCalculatorTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockToken.setTokenBalance(address(mockPool), current);
+        mockPool.setProjectSupply(1, current);
         uint256 oneTimeFee = 0;
         bool oneTimeRedemptionFailed = false;
         uint256 multipleTimesRedemptionFailedCount = 0;
@@ -158,7 +158,7 @@ contract FeeCalculatorTestFuzzy is Test {
                 total -= redemption;
                 current -= redemption;
                 mockPool.setTotalSupply(total);
-                mockToken.setTokenBalance(address(mockPool), current);
+                mockPool.setProjectSupply(1, current);
             } catch Error(string memory reason) {
                 multipleTimesRedemptionFailedCount++;
                 assertTrue(
@@ -204,7 +204,7 @@ contract FeeCalculatorTestFuzzy is Test {
         uint256 multipleTimesDepositFailedCount = 0;
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockToken.setTokenBalance(address(mockPool), current);
+        mockPool.setProjectSupply(1, current);
 
         uint256 oneTimeFee = 0;
 
@@ -236,7 +236,7 @@ contract FeeCalculatorTestFuzzy is Test {
                 total += deposit;
                 current += deposit;
                 mockPool.setTotalSupply(total);
-                mockToken.setTokenBalance(address(mockPool), current);
+                mockPool.setProjectSupply(1, current);
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(
@@ -280,7 +280,7 @@ contract FeeCalculatorTestFuzzy is Test {
         uint256 depositAmount = 100 * 1e18;
         // Set up mock pool
         mockPool.setTotalSupply(200 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 100 * 1e18);
+        mockPool.setProjectSupply(1, 100 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =

--- a/test/FeeCalculator.t.sol
+++ b/test/FeeCalculator.t.sol
@@ -70,7 +70,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -95,7 +95,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -120,7 +120,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e6 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1 * 1e18);
+        mockPool.setProjectSupply(1, 1 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -146,7 +146,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e6 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e6 * 1e18);
+        mockPool.setProjectSupply(1, 1e6 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -168,7 +168,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         address[] memory _recipients = new address[](2);
         _recipients[0] = feeRecipient1;
@@ -201,7 +201,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         address[] memory _recipients = new address[](2);
         _recipients[0] = feeRecipient1;
@@ -232,7 +232,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(53461 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 15462 * 1e18);
+        mockPool.setProjectSupply(1, 15462 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -252,7 +252,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         vm.expectRevert("Fee must be greater than 0");
@@ -269,7 +269,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         vm.expectRevert("Fee must be greater than 0");
@@ -283,7 +283,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -303,7 +303,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -328,7 +328,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         address[] memory _recipients = new address[](5);
         _recipients[0] = feeRecipient1;
@@ -376,7 +376,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         address[] memory _recipients = new address[](5);
         _recipients[0] = feeRecipient1;
@@ -419,7 +419,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(100 * 1e6 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e6 * 1e18);
+        mockPool.setProjectSupply(1, 1e6 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -439,7 +439,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         vm.expectRevert("depositAmount must be > 0");
@@ -453,7 +453,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1500 * 1e18);
+        mockPool.setProjectSupply(1, 1500 * 1e18);
 
         // Act
         vm.expectRevert(
@@ -473,7 +473,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1500 * 1e18);
+        mockPool.setProjectSupply(1, 1500 * 1e18);
 
         // Act & Assert
         vm.expectRevert(
@@ -493,7 +493,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         vm.expectRevert("The amount to be redeemed cannot exceed the current balance of the pool");
@@ -511,7 +511,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act & Assert
         vm.expectRevert("redemptionAmount must be > 0");
@@ -525,7 +525,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(0);
-        mockToken.setTokenBalance(address(mockPool), 0);
+        mockPool.setProjectSupply(1, 0);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -545,7 +545,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1);
-        mockToken.setTokenBalance(address(mockPool), 0);
+        mockPool.setProjectSupply(1, 0);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -569,7 +569,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         vm.expectRevert("redemptionAmount must be > 0");
@@ -587,7 +587,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockToken.setTokenBalance(address(mockPool), 1000);
+        mockPool.setProjectSupply(1, 1000);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -607,7 +607,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockToken.setTokenBalance(address(mockPool), 1000);
+        mockPool.setProjectSupply(1, 1000);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -627,7 +627,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockToken.setTokenBalance(address(mockPool), 999);
+        mockPool.setProjectSupply(1, 999);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -647,7 +647,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 0);
+        mockPool.setProjectSupply(1, 0);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -672,7 +672,7 @@ contract FeeCalculatorTest is Test {
         // Set up mock pool
         uint256 supply = 100000 * 1e18;
         mockPool.setTotalSupply(100000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), supply - 1);
+        mockPool.setProjectSupply(1, supply - 1);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -696,7 +696,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(56636794628913227180683983236);
-        mockToken.setTokenBalance(address(mockPool), 55661911070827884041095553095);
+        mockPool.setProjectSupply(1, 55661911070827884041095553095);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -840,7 +840,7 @@ contract FeeCalculatorTest is Test {
         // Arrange
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
         feeCalculator.setDepositFeeScale(0.09 * 1e18);
 
         // Act
@@ -856,7 +856,7 @@ contract FeeCalculatorTest is Test {
         // Arrange
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
         feeCalculator.setDepositFeeRatioScale(0.2 * 1e18);
 
         // Act
@@ -872,7 +872,7 @@ contract FeeCalculatorTest is Test {
         // Arrange
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1000 * 1e18);
+        mockPool.setProjectSupply(1, 1000 * 1e18);
         feeCalculator.setSingleAssetDepositRelativeFee(0.67 * 1e18);
 
         // Act
@@ -893,7 +893,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
         feeCalculator.setRedemptionFeeScale(0.4 * 1e18);
 
         // Act
@@ -914,7 +914,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
         feeCalculator.setRedemptionFeeShift(0.5 * 1e18);
 
         // Act
@@ -935,7 +935,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1000 * 1e18);
+        mockPool.setProjectSupply(1, 1000 * 1e18);
         feeCalculator.setSingleAssetRedemptionRelativeFee(0.83 * 1e18);
 
         // Act
@@ -957,7 +957,7 @@ contract FeeCalculatorTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(56636794628913227180683983236);
-        mockToken.setTokenBalance(address(mockPool), 55661911070827884041095553095);
+        mockPool.setProjectSupply(1, 55661911070827884041095553095);
         feeCalculator.setDustAssetRedemptionRelativeFee(0.91 * 1e18);
 
         // Act

--- a/test/FeeCalculatorLaunchParams.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParams.fuzzy.t.sol
@@ -46,7 +46,7 @@ contract FeeCalculatorLaunchParamsTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e12 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e9 * 1e18);
+        mockPool.setProjectSupply(1, 1e9 * 1e18);
 
         vm.expectRevert("Fee must be greater than 0");
         feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
@@ -66,7 +66,7 @@ contract FeeCalculatorLaunchParamsTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockToken.setTokenBalance(address(mockPool), current);
+        mockPool.setProjectSupply(1, current);
 
         // Act
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount) {}
@@ -111,7 +111,7 @@ contract FeeCalculatorLaunchParamsTestFuzzy is Test {
         uint256 multipleTimesDepositFailedCount = 0;
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockToken.setTokenBalance(address(mockPool), current);
+        mockPool.setProjectSupply(1, current);
 
         uint256 oneTimeFee = 0;
 
@@ -144,7 +144,7 @@ contract FeeCalculatorLaunchParamsTestFuzzy is Test {
                 total += deposit;
                 current += deposit;
                 mockPool.setTotalSupply(total);
-                mockToken.setTokenBalance(address(mockPool), current);
+                mockPool.setProjectSupply(1, current);
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(

--- a/test/FeeCalculatorLaunchParams.t.sol
+++ b/test/FeeCalculatorLaunchParams.t.sol
@@ -39,7 +39,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -62,7 +62,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         address[] memory _recipients = new address[](2);
         _recipients[0] = feeRecipient1;
@@ -95,7 +95,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         address[] memory _recipients = new address[](2);
         _recipients[0] = feeRecipient1;
@@ -126,7 +126,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(53461 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 15462 * 1e18);
+        mockPool.setProjectSupply(1, 15462 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -147,7 +147,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         vm.expectRevert("Fee must be greater than 0");
@@ -164,7 +164,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         vm.expectRevert("Fee must be greater than 0");
@@ -178,7 +178,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -199,7 +199,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -225,7 +225,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         address[] memory _recipients = new address[](5);
         _recipients[0] = feeRecipient1;
@@ -274,7 +274,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e4 * 1e18);
+        mockPool.setProjectSupply(1, 1e4 * 1e18);
 
         address[] memory _recipients = new address[](5);
         _recipients[0] = feeRecipient1;
@@ -318,7 +318,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(100 * 1e6 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1e6 * 1e18);
+        mockPool.setProjectSupply(1, 1e6 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -339,7 +339,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 500 * 1e18);
+        mockPool.setProjectSupply(1, 500 * 1e18);
 
         // Act
         vm.expectRevert("depositAmount must be > 0");
@@ -353,7 +353,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 1500 * 1e18);
+        mockPool.setProjectSupply(1, 1500 * 1e18);
 
         // Act
         vm.expectRevert(
@@ -369,7 +369,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(0);
-        mockToken.setTokenBalance(address(mockPool), 0);
+        mockPool.setProjectSupply(1, 0);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -389,7 +389,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1);
-        mockToken.setTokenBalance(address(mockPool), 0);
+        mockPool.setProjectSupply(1, 0);
 
         // Act
         vm.expectRevert("Deposit outside range");
@@ -403,7 +403,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockToken.setTokenBalance(address(mockPool), 1000);
+        mockPool.setProjectSupply(1, 1000);
 
         // Act
         FeeDistribution memory feeDistribution =
@@ -423,7 +423,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockToken.setTokenBalance(address(mockPool), 999);
+        mockPool.setProjectSupply(1, 999);
 
         // Act
         vm.expectRevert("Deposit outside range");
@@ -437,7 +437,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockToken.setTokenBalance(address(mockPool), 0);
+        mockPool.setProjectSupply(1, 0);
 
         // Act
         FeeDistribution memory feeDistribution =

--- a/test/TestUtilities.sol
+++ b/test/TestUtilities.sol
@@ -5,7 +5,9 @@
 // If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {VintageData} from "../src/interfaces/ITCO2.sol";
 
 library TestUtilities {
     function sumOf(uint256[] memory numbers) internal pure returns (uint256) {
@@ -19,6 +21,7 @@ library TestUtilities {
 
 contract MockPool is IERC20 {
     uint256 private _totalSupply;
+    mapping(uint256 => uint256) private _totalPerProjectSupply;
 
     function totalSupply() external view returns (uint256) {
         return _totalSupply;
@@ -28,8 +31,16 @@ contract MockPool is IERC20 {
         return _totalSupply;
     }
 
+    function totalPerProjectTCO2Supply(uint256 projectTokenId) external view returns (uint256) {
+        return _totalPerProjectSupply[projectTokenId];
+    }
+
     function setTotalSupply(uint256 ts) public {
         _totalSupply = ts;
+    }
+
+    function setProjectSupply(uint256 projectTokenId, uint256 ts) public {
+        _totalPerProjectSupply[projectTokenId] = ts;
     }
 
     function allowance(address, address) external pure override returns (uint256) {
@@ -56,10 +67,6 @@ contract MockPool is IERC20 {
 contract MockToken is IERC20 {
     mapping(address => uint256) public override balanceOf;
 
-    function setTokenBalance(address pool, uint256 balance) public {
-        balanceOf[pool] = balance;
-    }
-
     function allowance(address, address) external pure override returns (uint256) {
         return 0;
     }
@@ -78,5 +85,22 @@ contract MockToken is IERC20 {
 
     function totalSupply() external pure returns (uint256) {
         return 0;
+    }
+
+    function getVintageData() external pure returns (VintageData memory) {
+        return VintageData({
+            name: "test",
+            startTime: 0,
+            endTime: 0,
+            projectTokenId: 1,
+            totalVintageQuantity: 0,
+            isCorsiaCompliant: false,
+            isCCPcompliant: false,
+            coBenefits: "",
+            correspAdjustment: "",
+            additionalCertification: "",
+            uri: "",
+            registry: ""
+        });
     }
 }


### PR DESCRIPTION
Instead of calculating fees at the vintage level
we should be calculating fees at the project
level. In order to achieve that, use the newly
implemented pool function `totalPerProjectTCO2Supply` 
to determine how many credits of a project are
found in a pool.