### PR TITLE
feat(hh): add ERC1155 support

### DIFF
--- a/src/interfaces/IFeeCalculator.sol
+++ b/src/interfaces/IFeeCalculator.sol
@@ -31,7 +31,31 @@ interface IFeeCalculator {
     /// @param redemptionAmounts The amounts to be redeemed.
     /// @return feeDistribution How the fee is meant to be
     /// distributed among the fee recipients.
-    function calculateRedemptionFees(address pool, address[] calldata tco2s, uint256[] calldata redemptionAmounts)
+    function calculateRedemptionFees(address pool, address[] calldata tco2s, uint256[] calldata redemptionAmounts) 
+        external
+        view
+        returns (FeeDistribution memory feeDistribution);
+
+    /// @notice Calculates the deposit fee for a given amount of an ERC1155 project.
+    /// @param pool The address of the pool.
+    /// @param erc1155 The address of the ERC1155 project
+    /// @param tokenId The tokenId of the vintage.
+    /// @param depositAmount The amount to be deposited.
+    /// @return feeDistribution How the fee is meant to be
+    /// distributed among the fee recipients.
+    function calculateDepositFees(address pool, address erc1155, uint256 tokenId, uint256 depositAmount) 
+        external
+        view
+        returns (FeeDistribution memory feeDistribution);
+
+    /// @notice Calculates the redemption fees for a given amount on ERC1155 projects.
+    /// @param pool The address of the pool.
+    /// @param erc1155s The addresses of the ERC1155 projects.
+    /// @param tokenIds The tokenIds of the project vintages.
+    /// @param redemptionAmounts The amounts to be redeemed.
+    /// @return feeDistribution How the fee is meant to be
+    /// distributed among the fee recipients.
+    function calculateRedemptionFees(address pool, address[] calldata erc1155s, uint256[] calldata tokenIds, uint256[] calldata redemptionAmounts) 
         external
         view
         returns (FeeDistribution memory feeDistribution);

--- a/src/interfaces/IFeeCalculator.sol
+++ b/src/interfaces/IFeeCalculator.sol
@@ -31,7 +31,7 @@ interface IFeeCalculator {
     /// @param redemptionAmounts The amounts to be redeemed.
     /// @return feeDistribution How the fee is meant to be
     /// distributed among the fee recipients.
-    function calculateRedemptionFees(address pool, address[] calldata tco2s, uint256[] calldata redemptionAmounts) 
+    function calculateRedemptionFees(address pool, address[] calldata tco2s, uint256[] calldata redemptionAmounts)
         external
         view
         returns (FeeDistribution memory feeDistribution);
@@ -43,7 +43,7 @@ interface IFeeCalculator {
     /// @param depositAmount The amount to be deposited.
     /// @return feeDistribution How the fee is meant to be
     /// distributed among the fee recipients.
-    function calculateDepositFees(address pool, address erc1155, uint256 tokenId, uint256 depositAmount) 
+    function calculateDepositFees(address pool, address erc1155, uint256 tokenId, uint256 depositAmount)
         external
         view
         returns (FeeDistribution memory feeDistribution);
@@ -55,8 +55,10 @@ interface IFeeCalculator {
     /// @param redemptionAmounts The amounts to be redeemed.
     /// @return feeDistribution How the fee is meant to be
     /// distributed among the fee recipients.
-    function calculateRedemptionFees(address pool, address[] calldata erc1155s, uint256[] calldata tokenIds, uint256[] calldata redemptionAmounts) 
-        external
-        view
-        returns (FeeDistribution memory feeDistribution);
+    function calculateRedemptionFees(
+        address pool,
+        address[] calldata erc1155s,
+        uint256[] calldata tokenIds,
+        uint256[] calldata redemptionAmounts
+    ) external view returns (FeeDistribution memory feeDistribution);
 }

--- a/src/interfaces/IPool.sol
+++ b/src/interfaces/IPool.sol
@@ -16,8 +16,14 @@ interface IPool {
 
     /// @notice Exposes the total TCO2 supply of a project in a pool,
     /// tracked as the aggregation of deposit, redemmption and bridge actions
-    /// @param projectTokenId The token id of the project as it's tracked
-    /// in the CarbonProjects contract
+    /// @param tco2 The TCO2 address of the project
     /// @return supply Current supply of a project in the pool
-    function totalPerProjectTCO2Supply(uint256 projectTokenId) external view returns (uint256 supply);
+    function totalPerProjectSupply(address tco2) external view returns (uint256 supply);
+
+    /// @notice Exposes the total TCO2 supply of a project in a pool,
+    /// tracked as the aggregation of deposit, redemmption and bridge actions
+    /// @param erc1155 The ERC1155 address of the project
+    /// @param tokenId The token id of the project
+    /// @return supply Current supply of a project in the pool
+    function totalPerProjectSupply(address erc1155, uint256 tokenId) external view returns (uint256 supply);
 }

--- a/test/FeeCalculator/AbstractFeeCalculator.t.sol
+++ b/test/FeeCalculator/AbstractFeeCalculator.t.sol
@@ -37,8 +37,16 @@ abstract contract AbstractFeeCalculatorTest is Test {
     }
 
     function setProjectSupply(address token, uint256 supply) internal virtual;
-    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
-    function calculateRedemptionFees(address pool, address[] memory tokens, uint256[] memory amounts) internal view virtual returns (FeeDistribution memory);
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        virtual
+        returns (FeeDistribution memory);
+    function calculateRedemptionFees(address pool, address[] memory tokens, uint256[] memory amounts)
+        internal
+        view
+        virtual
+        returns (FeeDistribution memory);
 
     function testFeeSetupEmpty() public {
         address[] memory recipients = new address[](0);
@@ -102,8 +110,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 500 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -127,8 +134,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 1 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -153,8 +159,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 1e6 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -594,8 +599,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 1000);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -679,8 +683,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), supply - 1);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -703,8 +706,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 55661911070827884041095553095);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -848,8 +850,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setDepositFeeScale(0.09 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateDepositFees(address(mockPool), address(mockToken), 100 * 1e18);
+        FeeDistribution memory feeDistribution = calculateDepositFees(address(mockPool), address(mockToken), 100 * 1e18);
         uint256[] memory fees = feeDistribution.shares;
 
         // Assert
@@ -864,8 +865,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setDepositFeeRatioScale(0.2 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateDepositFees(address(mockPool), address(mockToken), 100 * 1e18);
+        FeeDistribution memory feeDistribution = calculateDepositFees(address(mockPool), address(mockToken), 100 * 1e18);
         uint256[] memory fees = feeDistribution.shares;
 
         // Assert
@@ -880,8 +880,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setSingleAssetDepositRelativeFee(0.67 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateDepositFees(address(mockPool), address(mockToken), 100 * 1e18);
+        FeeDistribution memory feeDistribution = calculateDepositFees(address(mockPool), address(mockToken), 100 * 1e18);
         uint256[] memory fees = feeDistribution.shares;
 
         // Assert
@@ -901,8 +900,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setRedemptionFeeScale(0.4 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         uint256[] memory fees = feeDistribution.shares;
 
         // Assert
@@ -922,8 +920,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setRedemptionFeeShift(0.5 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         uint256[] memory fees = feeDistribution.shares;
 
         // Assert
@@ -943,8 +940,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setSingleAssetRedemptionRelativeFee(0.83 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         uint256[] memory fees = feeDistribution.shares;
 
         assertEq(fees[0], 83 * 1e18);
@@ -965,8 +961,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         feeCalculator.setDustAssetRedemptionRelativeFee(0.91 * 1e18);
 
         // Act
-        FeeDistribution memory feeDistribution =
-            calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
+        FeeDistribution memory feeDistribution = calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts);
         uint256[] memory fees = feeDistribution.shares;
 
         // Assert

--- a/test/FeeCalculator/FeeCalculatorERC1155.t.sol
+++ b/test/FeeCalculator/FeeCalculatorERC1155.t.sol
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import "./AbstractFeeCalculator.t.sol";
+
+contract FeeCalculatorERC1155Test is AbstractFeeCalculatorTest {
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setERC1155Supply(address(token), 1, supply);
+    }
+
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                1,
+                amount
+            );
+    }
+
+    function calculateRedemptionFees(
+        address pool,
+        address[] memory tokens,
+        uint256[] memory amounts
+    ) internal view override returns (FeeDistribution memory) {
+        uint256[] memory tokenIds = new uint256[](tokens.length);
+        tokenIds[0] = 1;
+        return
+            feeCalculator.calculateRedemptionFees(
+                address(pool),
+                tokens,
+                tokenIds,
+                amounts
+            );
+    }
+}

--- a/test/FeeCalculator/FeeCalculatorERC1155.t.sol
+++ b/test/FeeCalculator/FeeCalculatorERC1155.t.sol
@@ -12,33 +12,23 @@ contract FeeCalculatorERC1155Test is AbstractFeeCalculatorTest {
         mockPool.setERC1155Supply(address(token), 1, supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                1,
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), 1, amount);
     }
 
-    function calculateRedemptionFees(
-        address pool,
-        address[] memory tokens,
-        uint256[] memory amounts
-    ) internal view override returns (FeeDistribution memory) {
+    function calculateRedemptionFees(address pool, address[] memory tokens, uint256[] memory amounts)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
         uint256[] memory tokenIds = new uint256[](tokens.length);
         tokenIds[0] = 1;
-        return
-            feeCalculator.calculateRedemptionFees(
-                address(pool),
-                tokens,
-                tokenIds,
-                amounts
-            );
+        return feeCalculator.calculateRedemptionFees(address(pool), tokens, tokenIds, amounts);
     }
 }

--- a/test/FeeCalculator/FeeCalculatorTCO2.t.sol
+++ b/test/FeeCalculator/FeeCalculatorTCO2.t.sol
@@ -12,29 +12,21 @@ contract FeeCalculatorTCO2Test is AbstractFeeCalculatorTest {
         mockPool.setTCO2Supply(address(token), supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), amount);
     }
 
-    function calculateRedemptionFees(
-        address pool,
-        address[] memory tokens,
-        uint256[] memory amounts
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateRedemptionFees(
-                address(pool),
-                tokens,
-                amounts
-            );
+    function calculateRedemptionFees(address pool, address[] memory tokens, uint256[] memory amounts)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateRedemptionFees(address(pool), tokens, amounts);
     }
 }

--- a/test/FeeCalculator/FeeCalculatorTCO2.t.sol
+++ b/test/FeeCalculator/FeeCalculatorTCO2.t.sol
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import "./AbstractFeeCalculator.t.sol";
+
+contract FeeCalculatorTCO2Test is AbstractFeeCalculatorTest {
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setTCO2Supply(address(token), supply);
+    }
+
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                amount
+            );
+    }
+
+    function calculateRedemptionFees(
+        address pool,
+        address[] memory tokens,
+        uint256[] memory amounts
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateRedemptionFees(
+                address(pool),
+                tokens,
+                amounts
+            );
+    }
+}

--- a/test/FeeCalculatorFuzzy/AbstractFeeCalculator.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/AbstractFeeCalculator.fuzzy.t.sol
@@ -32,7 +32,11 @@ abstract contract AbstractFeeCalculatorTestFuzzy is Test {
     }
 
     function setProjectSupply(address token, uint256 supply) internal virtual;
-    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        virtual
+        returns (FeeDistribution memory);
     function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
         uint8 numberOfRedemptions,
         uint128 _redemptionAmount,
@@ -77,7 +81,6 @@ abstract contract AbstractFeeCalculatorTestFuzzy is Test {
         );
     }
 
-
     function testCalculateDepositFeesFuzzy_DepositDividedIntoOneChunkFeesGreaterOrEqualToOneDeposit(
         uint256 depositAmount,
         uint256 current,
@@ -88,7 +91,6 @@ abstract contract AbstractFeeCalculatorTestFuzzy is Test {
             1, depositAmount, current, total
         );
     }
-
 
     function testFeeSetupFuzzy(address[] memory recipients, uint8 firstShare) public {
         vm.assume(recipients.length <= 100);

--- a/test/FeeCalculatorFuzzy/AbstractFeeCalculator.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/AbstractFeeCalculator.fuzzy.t.sol
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {FeeCalculator} from "../../src/FeeCalculator.sol";
+import {FeeDistribution} from "../../src/interfaces/IFeeCalculator.sol";
+import {SD59x18, sd, intoUint256 as sdIntoUint256} from "@prb/math/src/SD59x18.sol";
+import {UD60x18, ud, intoUint256} from "@prb/math/src/UD60x18.sol";
+import "../TestUtilities.sol";
+
+abstract contract AbstractFeeCalculatorTestFuzzy is Test {
+    using TestUtilities for uint256[];
+
+    FeeCalculator public feeCalculator;
+    MockPool public mockPool;
+    MockToken public mockToken;
+    address public feeRecipient = 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B;
+
+    function setUp() public {
+        feeCalculator = new FeeCalculator();
+        mockPool = new MockPool();
+        mockToken = new MockToken();
+        address[] memory recipients = new address[](1);
+        recipients[0] = feeRecipient;
+        uint256[] memory feeShares = new uint256[](1);
+        feeShares[0] = 100;
+        feeCalculator.feeSetup(recipients, feeShares);
+    }
+
+    function setProjectSupply(address token, uint256 supply) internal virtual;
+    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
+    function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
+        uint8 numberOfRedemptions,
+        uint128 _redemptionAmount,
+        uint128 _current,
+        uint128 _total
+    ) public virtual;
+    function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
+        uint8 numberOfDeposits,
+        uint256 depositAmount,
+        uint256 current,
+        uint256 total
+    ) public virtual;
+
+    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldThrowError(uint256 depositAmount)
+        public
+    {
+        vm.assume(depositAmount <= 1e-14 * 1e18);
+        vm.assume(depositAmount >= 10);
+
+        //Note! This is a bug, where a very small deposit to a very large pool
+        //causes a == b because of precision limited by ratioDenominator in FeeCalculator
+
+        // Arrange
+        // Set up your test data
+
+        // Set up mock pool
+        mockPool.setTotalSupply(1e12 * 1e18);
+        setProjectSupply(address(mockToken), 1e9 * 1e18);
+
+        vm.expectRevert("Fee must be greater than 0");
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+    }
+
+    function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoOneChunkFeesGreaterOrEqualToOneRedemption(
+        uint128 _redemptionAmount,
+        uint128 _current,
+        uint128 _total
+    ) public {
+        //just a sanity check
+        testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
+            1, _redemptionAmount, _current, _total
+        );
+    }
+
+
+    function testCalculateDepositFeesFuzzy_DepositDividedIntoOneChunkFeesGreaterOrEqualToOneDeposit(
+        uint256 depositAmount,
+        uint256 current,
+        uint256 total
+    ) public {
+        //just a sanity check
+        testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
+            1, depositAmount, current, total
+        );
+    }
+
+
+    function testFeeSetupFuzzy(address[] memory recipients, uint8 firstShare) public {
+        vm.assume(recipients.length <= 100);
+        vm.assume(recipients.length > 1); //at least two recipients
+        vm.assume(firstShare <= 100);
+        vm.assume(firstShare > 0);
+
+        uint256[] memory feeShares = new uint256[](recipients.length);
+
+        uint256 shareLeft = 100 - firstShare;
+        feeShares[0] = firstShare;
+        uint256 equalShare = shareLeft / (recipients.length - 1);
+        uint256 leftShare = shareLeft % (recipients.length - 1);
+
+        for (uint256 i = 1; i < recipients.length; i++) {
+            feeShares[i] = equalShare;
+        }
+        feeShares[recipients.length - 1] += leftShare; //last one gets additional share
+        feeCalculator.feeSetup(recipients, feeShares);
+
+        uint256 depositAmount = 100 * 1e18;
+        // Set up mock pool
+        mockPool.setTotalSupply(200 * 1e18);
+        setProjectSupply(address(mockToken), 100 * 1e18);
+
+        // Act
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        address[] memory gotRecipients = feeDistribution.recipients;
+        uint256[] memory fees = feeDistribution.shares;
+
+        // Assert
+        assertEq(gotRecipients.length, recipients.length);
+        for (uint256 i = 0; i < recipients.length; i++) {
+            assertEq(gotRecipients[i], recipients[i]);
+        }
+
+        assertEq(fees.sumOf(), 11526003792614720250);
+
+        assertApproxEqAbs(fees[0], 11526003792614720250 * uint256(firstShare) / 100, recipients.length - 1 + 1); //first fee might get the rest from division
+
+        for (uint256 i = 1; i < recipients.length - 1; i++) {
+            assertApproxEqAbs(fees[i], 11526003792614720250 * equalShare / 100, 1);
+        }
+        assertApproxEqAbs(fees[recipients.length - 1], 11526003792614720250 * (equalShare + leftShare) / 100, 1);
+    }
+}

--- a/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
@@ -1,0 +1,219 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import "./AbstractFeeCalculator.fuzzy.t.sol";
+
+contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
+    using TestUtilities for uint256[];
+    
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setERC1155Supply(address(token), 1, supply);
+    }
+
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                1,
+                amount
+            );
+    }
+
+
+    function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public {
+        //vm.assume(depositAmount > 0);
+        //vm.assume(total > 0);
+        //vm.assume(current > 0);
+        vm.assume(total >= current);
+        vm.assume(depositAmount < 1e20 * 1e18);
+        vm.assume(depositAmount > 0);
+        vm.assume(total < 1e20 * 1e18);
+
+        // Arrange
+        // Set up your test data
+
+        // Set up mock pool
+        mockPool.setTotalSupply(total);
+        mockPool.setTCO2Supply(address(mockToken), current);
+
+        // Act
+        try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, depositAmount) {}
+        catch Error(string memory reason) {
+            assertTrue(
+                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+            );
+        }
+    }
+
+    function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
+        uint8 numberOfRedemptions,
+        uint128 _redemptionAmount,
+        uint128 _current,
+        uint128 _total
+    ) public override {
+        vm.assume(0 < numberOfRedemptions);
+        vm.assume(_total >= _current);
+        vm.assume(_redemptionAmount <= _current);
+        vm.assume(_redemptionAmount < 1e20 * 1e18);
+        vm.assume(_total < 1e20 * 1e18);
+        vm.assume(_redemptionAmount > 1e-6 * 1e18);
+        vm.assume(_current > 1e12);
+
+        uint256 redemptionAmount = _redemptionAmount;
+        uint256 current = _current;
+        uint256 total = _total;
+
+        SD59x18 dustAssetRedemptionRelativeFee = sd(0.3 * 1e18);
+
+        // Arrange
+        // Set up your test data
+
+        // Set up mock pool
+        mockPool.setTotalSupply(total);
+        setProjectSupply(address(mockToken), current);
+        uint256 oneTimeFee = 0;
+        bool oneTimeRedemptionFailed = false;
+        uint256 multipleTimesRedemptionFailedCount = 0;
+
+        address[] memory tco2s = new address[](1);
+        tco2s[0] = address(mockToken);
+        uint256[] memory tokenIds = new uint256[](1);
+        tokenIds[0] = 1;
+        uint256[] memory redemptionAmounts = new uint256[](1);
+        redemptionAmounts[0] = redemptionAmount;
+
+        // Act
+        try feeCalculator.calculateRedemptionFees(address(mockPool), tco2s, tokenIds, redemptionAmounts) returns (
+            FeeDistribution memory feeDistribution
+        ) {
+            oneTimeFee = feeDistribution.shares.sumOf();
+        } catch Error(string memory reason) {
+            oneTimeRedemptionFailed = true;
+            assertTrue(
+                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+            );
+        }
+
+        /// @dev if we fail at the first try, we do not want to test the rest of the function
+        vm.assume(oneTimeRedemptionFailed == false);
+        /// @dev This prevents the case when the fee is so small that it is being calculated using dustAssetRedemptionRelativeFee
+        /// @dev we don not want to test this case
+        vm.assume(oneTimeFee != sdIntoUint256(sd(int256(redemptionAmount)) * dustAssetRedemptionRelativeFee));
+
+        uint256 equalRedemption = redemptionAmount / numberOfRedemptions;
+        uint256 restRedemption = redemptionAmount % numberOfRedemptions;
+        uint256 feeFromDividedRedemptions = 0;
+
+        for (uint256 i = 0; i < numberOfRedemptions; i++) {
+            uint256 redemption = equalRedemption + (i == 0 ? restRedemption : 0);
+            redemptionAmounts[0] = redemption;
+            try feeCalculator.calculateRedemptionFees(address(mockPool), tco2s, tokenIds, redemptionAmounts) returns (
+                FeeDistribution memory feeDistribution
+            ) {
+                feeFromDividedRedemptions += feeDistribution.shares.sumOf();
+                total -= redemption;
+                current -= redemption;
+                mockPool.setTotalSupply(total);
+                setProjectSupply(address(mockToken), current);
+            } catch Error(string memory reason) {
+                multipleTimesRedemptionFailedCount++;
+                assertTrue(
+                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                );
+            }
+        }
+
+        // @dev we allow for 0.1% error
+        assertGe(1001 * feeFromDividedRedemptions / 1000, oneTimeFee);
+    }
+
+
+    function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
+        uint8 numberOfDeposits,
+        uint256 depositAmount,
+        uint256 current,
+        uint256 total
+    ) public override {
+        vm.assume(0 < numberOfDeposits);
+        vm.assume(total >= current);
+
+        vm.assume(depositAmount < 1e20 * 1e18);
+        vm.assume(total < 1e20 * 1e18);
+
+        vm.assume(depositAmount > 1e-6 * 1e18);
+
+        // Arrange
+        // Set up your test data
+        bool oneTimeDepositFailed = false;
+        uint256 multipleTimesDepositFailedCount = 0;
+        // Set up mock pool
+        mockPool.setTotalSupply(total);
+        setProjectSupply(address(mockToken), current);
+
+        uint256 oneTimeFee = 0;
+
+        // Act
+        try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, depositAmount) returns (
+            FeeDistribution memory feeDistribution
+        ) {
+            oneTimeFee = feeDistribution.shares.sumOf();
+        } catch Error(string memory reason) {
+            oneTimeDepositFailed = true;
+            assertTrue(
+                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+            );
+        }
+
+        uint256 equalDeposit = depositAmount / numberOfDeposits;
+        uint256 restDeposit = depositAmount % numberOfDeposits;
+        uint256 feeFromDividedDeposits = 0;
+
+        for (uint256 i = 0; i < numberOfDeposits; i++) {
+            uint256 deposit = equalDeposit + (i == 0 ? restDeposit : 0);
+
+            try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, deposit) returns (
+                FeeDistribution memory feeDistribution
+            ) {
+                feeFromDividedDeposits += feeDistribution.shares.sumOf();
+                total += deposit;
+                current += deposit;
+                mockPool.setTotalSupply(total);
+                setProjectSupply(address(mockToken), current);
+            } catch Error(string memory reason) {
+                multipleTimesDepositFailedCount++;
+                assertTrue(
+                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                );
+            }
+        }
+
+        // Assert
+        if (multipleTimesDepositFailedCount == 0 && !oneTimeDepositFailed) {
+            uint256 maximumAllowedErrorPercentage = (numberOfDeposits <= 1) ? 0 : 2;
+            if (
+                oneTimeFee + feeFromDividedDeposits > 1e-8 * 1e18 // we skip assertion for extremely small fees (basically zero fees) because of numerical errors
+            ) {
+                assertGe((maximumAllowedErrorPercentage + 100) * feeFromDividedDeposits / 100, oneTimeFee);
+            } //we add 1% tolerance for numerical errors
+        }
+    }
+}

--- a/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
@@ -9,25 +9,19 @@ import "./AbstractFeeCalculator.fuzzy.t.sol";
 
 contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
     using TestUtilities for uint256[];
-    
+
     function setProjectSupply(address token, uint256 supply) internal override {
         mockPool.setERC1155Supply(address(token), 1, supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                1,
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), 1, amount);
     }
-
 
     function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public {
         //vm.assume(depositAmount > 0);
@@ -141,7 +135,6 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         // @dev we allow for 0.1% error
         assertGe(1001 * feeFromDividedRedemptions / 1000, oneTimeFee);
     }
-
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
         uint8 numberOfDeposits,

--- a/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
@@ -5,56 +5,29 @@
 // If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
 pragma solidity ^0.8.13;
 
-import {Test, console2} from "forge-std/Test.sol";
-import {FeeCalculator} from "../src/FeeCalculator.sol";
-import {FeeDistribution} from "../src/interfaces/IFeeCalculator.sol";
-import {SD59x18, sd, intoUint256 as sdIntoUint256} from "@prb/math/src/SD59x18.sol";
-import {UD60x18, ud, intoUint256} from "@prb/math/src/UD60x18.sol";
-import "./TestUtilities.sol";
+import "./AbstractFeeCalculator.fuzzy.t.sol";
 
-contract FeeCalculatorTestFuzzy is Test {
+contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
     using TestUtilities for uint256[];
-
-    FeeCalculator public feeCalculator;
-    MockPool public mockPool;
-    MockToken public mockToken;
-    address public feeRecipient = 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B;
-
-    function setUp() public {
-        feeCalculator = new FeeCalculator();
-        mockPool = new MockPool();
-        mockToken = new MockToken();
-        address[] memory recipients = new address[](1);
-        recipients[0] = feeRecipient;
-        uint256[] memory feeShares = new uint256[](1);
-        feeShares[0] = 100;
-        feeCalculator.feeSetup(recipients, feeShares);
+    
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setTCO2Supply(address(token), supply);
     }
 
-    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldThrowError(uint256 depositAmount)
-        public
-    {
-        vm.assume(depositAmount <= 1e-14 * 1e18);
-        vm.assume(depositAmount >= 10);
-
-        //Note! This is a bug, where a very small deposit to a very large pool
-        //causes a == b because of precision limited by ratioDenominator in FeeCalculator
-
-        // Arrange
-        // Set up your test data
-
-        // Set up mock pool
-        mockPool.setTotalSupply(1e12 * 1e18);
-        mockPool.setProjectSupply(1, 1e9 * 1e18);
-
-        vm.expectRevert("Fee must be greater than 0");
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                amount
+            );
     }
 
     function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public {
-        //vm.assume(depositAmount > 0);
-        //vm.assume(total > 0);
-        //vm.assume(current > 0);
         vm.assume(total >= current);
         vm.assume(depositAmount < 1e20 * 1e18);
         vm.assume(depositAmount > 0);
@@ -65,28 +38,17 @@ contract FeeCalculatorTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockPool.setProjectSupply(1, current);
+        mockPool.setTCO2Supply(address(mockToken), current);
 
         // Act
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount) {}
         catch Error(string memory reason) {
             assertTrue(
                 keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to deposit amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to deposit amount'"
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
             );
         }
-    }
-
-    function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoOneChunkFeesGreaterOrEqualToOneRedemption(
-        uint128 _redemptionAmount,
-        uint128 _current,
-        uint128 _total
-    ) public {
-        //just a sanity check
-        testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
-            1, _redemptionAmount, _current, _total
-        );
     }
 
     function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
@@ -94,7 +56,7 @@ contract FeeCalculatorTestFuzzy is Test {
         uint128 _redemptionAmount,
         uint128 _current,
         uint128 _total
-    ) public {
+    ) public override {
         vm.assume(0 < numberOfRedemptions);
         vm.assume(_total >= _current);
         vm.assume(_redemptionAmount <= _current);
@@ -114,7 +76,7 @@ contract FeeCalculatorTestFuzzy is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockPool.setProjectSupply(1, current);
+        setProjectSupply(address(mockToken), current);
         uint256 oneTimeFee = 0;
         bool oneTimeRedemptionFailed = false;
         uint256 multipleTimesRedemptionFailedCount = 0;
@@ -133,8 +95,8 @@ contract FeeCalculatorTestFuzzy is Test {
             oneTimeRedemptionFailed = true;
             assertTrue(
                 keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to deposit amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to deposit amount'"
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
             );
         }
 
@@ -158,13 +120,13 @@ contract FeeCalculatorTestFuzzy is Test {
                 total -= redemption;
                 current -= redemption;
                 mockPool.setTotalSupply(total);
-                mockPool.setProjectSupply(1, current);
+                setProjectSupply(address(mockToken), current);
             } catch Error(string memory reason) {
                 multipleTimesRedemptionFailedCount++;
                 assertTrue(
                     keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to deposit amount")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to deposit amount'"
+                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
                 );
             }
         }
@@ -173,23 +135,13 @@ contract FeeCalculatorTestFuzzy is Test {
         assertGe(1001 * feeFromDividedRedemptions / 1000, oneTimeFee);
     }
 
-    function testCalculateDepositFeesFuzzy_DepositDividedIntoOneChunkFeesGreaterOrEqualToOneDeposit(
-        uint256 depositAmount,
-        uint256 current,
-        uint256 total
-    ) public {
-        //just a sanity check
-        testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
-            1, depositAmount, current, total
-        );
-    }
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
         uint8 numberOfDeposits,
         uint256 depositAmount,
         uint256 current,
         uint256 total
-    ) public {
+    ) public override {
         vm.assume(0 < numberOfDeposits);
         vm.assume(total >= current);
 
@@ -204,7 +156,7 @@ contract FeeCalculatorTestFuzzy is Test {
         uint256 multipleTimesDepositFailedCount = 0;
         // Set up mock pool
         mockPool.setTotalSupply(total);
-        mockPool.setProjectSupply(1, current);
+        setProjectSupply(address(mockToken), current);
 
         uint256 oneTimeFee = 0;
 
@@ -217,8 +169,8 @@ contract FeeCalculatorTestFuzzy is Test {
             oneTimeDepositFailed = true;
             assertTrue(
                 keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to deposit amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to deposit amount'"
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
             );
         }
 
@@ -236,13 +188,13 @@ contract FeeCalculatorTestFuzzy is Test {
                 total += deposit;
                 current += deposit;
                 mockPool.setTotalSupply(total);
-                mockPool.setProjectSupply(1, current);
+                setProjectSupply(address(mockToken), current);
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(
                     keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to deposit amount")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to deposit amount'"
+                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
                 );
             }
         }
@@ -256,51 +208,5 @@ contract FeeCalculatorTestFuzzy is Test {
                 assertGe((maximumAllowedErrorPercentage + 100) * feeFromDividedDeposits / 100, oneTimeFee);
             } //we add 1% tolerance for numerical errors
         }
-    }
-
-    function testFeeSetupFuzzy(address[] memory recipients, uint8 firstShare) public {
-        vm.assume(recipients.length <= 100);
-        vm.assume(recipients.length > 1); //at least two recipients
-        vm.assume(firstShare <= 100);
-        vm.assume(firstShare > 0);
-
-        uint256[] memory feeShares = new uint256[](recipients.length);
-
-        uint256 shareLeft = 100 - firstShare;
-        feeShares[0] = firstShare;
-        uint256 equalShare = shareLeft / (recipients.length - 1);
-        uint256 leftShare = shareLeft % (recipients.length - 1);
-
-        for (uint256 i = 1; i < recipients.length; i++) {
-            feeShares[i] = equalShare;
-        }
-        feeShares[recipients.length - 1] += leftShare; //last one gets additional share
-        feeCalculator.feeSetup(recipients, feeShares);
-
-        uint256 depositAmount = 100 * 1e18;
-        // Set up mock pool
-        mockPool.setTotalSupply(200 * 1e18);
-        mockPool.setProjectSupply(1, 100 * 1e18);
-
-        // Act
-        FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
-        address[] memory gotRecipients = feeDistribution.recipients;
-        uint256[] memory fees = feeDistribution.shares;
-
-        // Assert
-        assertEq(gotRecipients.length, recipients.length);
-        for (uint256 i = 0; i < recipients.length; i++) {
-            assertEq(gotRecipients[i], recipients[i]);
-        }
-
-        assertEq(fees.sumOf(), 11526003792614720250);
-
-        assertApproxEqAbs(fees[0], 11526003792614720250 * uint256(firstShare) / 100, recipients.length - 1 + 1); //first fee might get the rest from division
-
-        for (uint256 i = 1; i < recipients.length - 1; i++) {
-            assertApproxEqAbs(fees[i], 11526003792614720250 * equalShare / 100, 1);
-        }
-        assertApproxEqAbs(fees[recipients.length - 1], 11526003792614720250 * (equalShare + leftShare) / 100, 1);
     }
 }

--- a/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
@@ -9,22 +9,18 @@ import "./AbstractFeeCalculator.fuzzy.t.sol";
 
 contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
     using TestUtilities for uint256[];
-    
+
     function setProjectSupply(address token, uint256 supply) internal override {
         mockPool.setTCO2Supply(address(token), supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), amount);
     }
 
     function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public {
@@ -134,7 +130,6 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         // @dev we allow for 0.1% error
         assertGe(1001 * feeFromDividedRedemptions / 1000, oneTimeFee);
     }
-
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
         uint8 numberOfDeposits,

--- a/test/FeeCalculatorLaunchParams/AbstractFeeCalculatorLaunchParams.t.sol
+++ b/test/FeeCalculatorLaunchParams/AbstractFeeCalculatorLaunchParams.t.sol
@@ -33,7 +33,11 @@ abstract contract AbstractFeeCalculatorLaunchParamsTest is Test {
     }
 
     function setProjectSupply(address token, uint256 supply) internal virtual;
-    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        virtual
+        returns (FeeDistribution memory);
 
     function testCalculateDepositFeesNormalCase() public {
         // Arrange

--- a/test/FeeCalculatorLaunchParams/AbstractFeeCalculatorLaunchParams.t.sol
+++ b/test/FeeCalculatorLaunchParams/AbstractFeeCalculatorLaunchParams.t.sol
@@ -6,11 +6,11 @@
 pragma solidity ^0.8.13;
 
 import {Test, console2} from "forge-std/Test.sol";
-import {FeeCalculator} from "../src/FeeCalculator.sol";
-import {FeeDistribution} from "../src/interfaces/IFeeCalculator.sol";
-import "./TestUtilities.sol";
+import {FeeCalculator} from "../../src/FeeCalculator.sol";
+import {FeeDistribution} from "../../src/interfaces/IFeeCalculator.sol";
+import "../TestUtilities.sol";
 
-contract FeeCalculatorLaunchParamsTest is Test {
+abstract contract AbstractFeeCalculatorLaunchParamsTest is Test {
     using TestUtilities for uint256[];
 
     FeeCalculator public feeCalculator;
@@ -32,6 +32,9 @@ contract FeeCalculatorLaunchParamsTest is Test {
         feeCalculator.setDepositFeeRatioScale(1.25 * 1e18);
     }
 
+    function setProjectSupply(address token, uint256 supply) internal virtual;
+    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
+
     function testCalculateDepositFeesNormalCase() public {
         // Arrange
         // Set up your test data
@@ -39,11 +42,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockPool.setProjectSupply(1, 500 * 1e18);
+        setProjectSupply(address(mockToken), 500 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -62,7 +65,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockPool.setProjectSupply(1, 500 * 1e18);
+        setProjectSupply(address(mockToken), 500 * 1e18);
 
         address[] memory _recipients = new address[](2);
         _recipients[0] = feeRecipient1;
@@ -74,7 +77,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -95,7 +98,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockPool.setProjectSupply(1, 500 * 1e18);
+        setProjectSupply(address(mockToken), 500 * 1e18);
 
         address[] memory _recipients = new address[](2);
         _recipients[0] = feeRecipient1;
@@ -107,7 +110,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -126,11 +129,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(53461 * 1e18);
-        mockPool.setProjectSupply(1, 15462 * 1e18);
+        setProjectSupply(address(mockToken), 15462 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -147,11 +150,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockPool.setProjectSupply(1, 1e4 * 1e18);
+        setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
         vm.expectRevert("Fee must be greater than 0");
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
 
     function testCalculateDepositFees_DepositOfHundredWei_ShouldThrowError() public {
@@ -164,11 +167,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockPool.setProjectSupply(1, 1e4 * 1e18);
+        setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
         vm.expectRevert("Fee must be greater than 0");
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
 
     function testCalculateDepositFees_DepositOfHundredThousandsPartOfOne_NonzeroFee() public {
@@ -178,11 +181,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockPool.setProjectSupply(1, 1e4 * 1e18);
+        setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -199,11 +202,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockPool.setProjectSupply(1, 1e4 * 1e18);
+        setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -225,7 +228,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockPool.setProjectSupply(1, 1e4 * 1e18);
+        setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         address[] memory _recipients = new address[](5);
         _recipients[0] = feeRecipient1;
@@ -243,7 +246,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -274,7 +277,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1e5 * 1e18);
-        mockPool.setProjectSupply(1, 1e4 * 1e18);
+        setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         address[] memory _recipients = new address[](5);
         _recipients[0] = feeRecipient1;
@@ -292,7 +295,7 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -318,11 +321,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(100 * 1e6 * 1e18);
-        mockPool.setProjectSupply(1, 1e6 * 1e18);
+        setProjectSupply(address(mockToken), 1e6 * 1e18);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -339,11 +342,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockPool.setProjectSupply(1, 500 * 1e18);
+        setProjectSupply(address(mockToken), 500 * 1e18);
 
         // Act
         vm.expectRevert("depositAmount must be > 0");
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
 
     function testCalculateDepositFees_CurrentGreaterThanTotal_ExceptionShouldBeThrown() public {
@@ -353,13 +356,13 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockPool.setProjectSupply(1, 1500 * 1e18);
+        setProjectSupply(address(mockToken), 1500 * 1e18);
 
         // Act
         vm.expectRevert(
             "The total volume in the pool must be greater than or equal to the volume for an individual asset"
         );
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
 
     function testCalculateDepositFees_EmptyPool_FeeCappedAt10Percent() public {
@@ -369,11 +372,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(0);
-        mockPool.setProjectSupply(1, 0);
+        setProjectSupply(address(mockToken), 0);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -389,11 +392,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1);
-        mockPool.setProjectSupply(1, 0);
+        setProjectSupply(address(mockToken), 0);
 
         // Act
         vm.expectRevert("Deposit outside range");
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
 
     function testCalculateDepositFees_TotalEqualCurrent_FeeCappedAt10Percent() public {
@@ -403,11 +406,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockPool.setProjectSupply(1, 1000);
+        setProjectSupply(address(mockToken), 1000);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 
@@ -423,11 +426,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000);
-        mockPool.setProjectSupply(1, 999);
+        setProjectSupply(address(mockToken), 999);
 
         // Act
         vm.expectRevert("Deposit outside range");
-        feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
 
     function testCalculateDepositFees_ZeroCurrent_NormalFees() public {
@@ -437,11 +440,11 @@ contract FeeCalculatorLaunchParamsTest is Test {
 
         // Set up mock pool
         mockPool.setTotalSupply(1000 * 1e18);
-        mockPool.setProjectSupply(1, 0);
+        setProjectSupply(address(mockToken), 0);
 
         // Act
         FeeDistribution memory feeDistribution =
-            feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
         address[] memory recipients = feeDistribution.recipients;
         uint256[] memory fees = feeDistribution.shares;
 

--- a/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsERC1155.t.sol
+++ b/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsERC1155.t.sol
@@ -7,24 +7,17 @@ pragma solidity ^0.8.13;
 
 import "./AbstractFeeCalculatorLaunchParams.t.sol";
 
-contract FeeCalculatorLaunchParamsERC1155Test is
-    AbstractFeeCalculatorLaunchParamsTest
-{
+contract FeeCalculatorLaunchParamsERC1155Test is AbstractFeeCalculatorLaunchParamsTest {
     function setProjectSupply(address token, uint256 supply) internal override {
         mockPool.setERC1155Supply(address(token), 1, supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                1,
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), 1, amount);
     }
 }

--- a/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsERC1155.t.sol
+++ b/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsERC1155.t.sol
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import "./AbstractFeeCalculatorLaunchParams.t.sol";
+
+contract FeeCalculatorLaunchParamsERC1155Test is
+    AbstractFeeCalculatorLaunchParamsTest
+{
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setERC1155Supply(address(token), 1, supply);
+    }
+
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                1,
+                amount
+            );
+    }
+}

--- a/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsTCO2.t.sol
+++ b/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsTCO2.t.sol
@@ -7,23 +7,17 @@ pragma solidity ^0.8.13;
 
 import "./AbstractFeeCalculatorLaunchParams.t.sol";
 
-contract FeeCalculatorLaunchParamsTCO2Test is
-    AbstractFeeCalculatorLaunchParamsTest
-{
+contract FeeCalculatorLaunchParamsTCO2Test is AbstractFeeCalculatorLaunchParamsTest {
     function setProjectSupply(address token, uint256 supply) internal override {
         mockPool.setTCO2Supply(address(token), supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), amount);
     }
 }

--- a/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsTCO2.t.sol
+++ b/test/FeeCalculatorLaunchParams/FeeCalculatorLaunchParamsTCO2.t.sol
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import "./AbstractFeeCalculatorLaunchParams.t.sol";
+
+contract FeeCalculatorLaunchParamsTCO2Test is
+    AbstractFeeCalculatorLaunchParamsTest
+{
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setTCO2Supply(address(token), supply);
+    }
+
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                amount
+            );
+    }
+}

--- a/test/FeeCalculatorLaunchParamsFuzzy/AbstractFeeCalculatorLaunchParams.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/AbstractFeeCalculatorLaunchParams.fuzzy.t.sol
@@ -34,7 +34,11 @@ abstract contract AbstractFeeCalculatorLaunchParamsTestFuzzy is Test {
     }
 
     function setProjectSupply(address token, uint256 supply) internal virtual;
-    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        virtual
+        returns (FeeDistribution memory);
     function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public virtual;
     function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
         uint8 numberOfDeposits,
@@ -62,7 +66,6 @@ abstract contract AbstractFeeCalculatorLaunchParamsTestFuzzy is Test {
         vm.expectRevert("Fee must be greater than 0");
         calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
     }
-
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoOneChunkFeesGreaterOrEqualToOneDeposit(
         uint256 depositAmount,

--- a/test/FeeCalculatorLaunchParamsFuzzy/AbstractFeeCalculatorLaunchParams.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/AbstractFeeCalculatorLaunchParams.fuzzy.t.sol
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {FeeCalculator} from "../../src/FeeCalculator.sol";
+import {FeeDistribution} from "../../src/interfaces/IFeeCalculator.sol";
+import "../TestUtilities.sol";
+import "forge-std/console.sol";
+
+abstract contract AbstractFeeCalculatorLaunchParamsTestFuzzy is Test {
+    using TestUtilities for uint256[];
+
+    FeeCalculator public feeCalculator;
+    MockPool public mockPool;
+    MockToken public mockToken;
+    address public feeRecipient = 0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B;
+
+    function setUp() public {
+        feeCalculator = new FeeCalculator();
+        mockPool = new MockPool();
+        mockToken = new MockToken();
+        address[] memory recipients = new address[](1);
+        recipients[0] = feeRecipient;
+        uint256[] memory feeShares = new uint256[](1);
+        feeShares[0] = 100;
+        feeCalculator.feeSetup(recipients, feeShares);
+        // set up fee calculator launch params
+        feeCalculator.setDepositFeeScale(0.15 * 1e18);
+        feeCalculator.setDepositFeeRatioScale(1.25 * 1e18);
+    }
+
+    function setProjectSupply(address token, uint256 supply) internal virtual;
+    function calculateDepositFees(address pool, address token, uint256 amount) internal view virtual returns (FeeDistribution memory);
+    function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public virtual;
+    function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
+        uint8 numberOfDeposits,
+        uint256 depositAmount,
+        uint256 current,
+        uint256 total
+    ) public virtual;
+
+    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldThrowError(uint256 depositAmount)
+        public
+    {
+        vm.assume(depositAmount <= 1e-14 * 1e18);
+        vm.assume(depositAmount >= 10);
+
+        //Note! This is a bug, where a very small deposit to a very large pool
+        //causes a == b because of precision limited by ratioDenominator in FeeCalculator
+
+        // Arrange
+        // Set up your test data
+
+        // Set up mock pool
+        mockPool.setTotalSupply(1e12 * 1e18);
+        setProjectSupply(address(mockToken), 1e9 * 1e18);
+
+        vm.expectRevert("Fee must be greater than 0");
+        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+    }
+
+
+    function testCalculateDepositFeesFuzzy_DepositDividedIntoOneChunkFeesGreaterOrEqualToOneDeposit(
+        uint256 depositAmount,
+        uint256 current,
+        uint256 total
+    ) public {
+        //just a sanity check
+        testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
+            1, depositAmount, current, total
+        );
+    }
+}

--- a/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsERC1155.fuzzy.t.sol
@@ -14,18 +14,13 @@ contract FeeCalculatorLaunchParamsERC1155TestFuzzy is AbstractFeeCalculatorLaunc
         mockPool.setERC1155Supply(address(token), 1, supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                1,
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), 1, amount);
     }
 
     function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public override {

--- a/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsERC1155.fuzzy.t.sol
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2024 Toucan Protocol
+//
+// SPDX-License-Identifier: UNLICENSED
+
+// If you encounter a vulnerability or an issue, please contact <info@neutralx.com>
+pragma solidity ^0.8.13;
+
+import "./AbstractFeeCalculatorLaunchParams.fuzzy.t.sol";
+
+contract FeeCalculatorLaunchParamsERC1155TestFuzzy is AbstractFeeCalculatorLaunchParamsTestFuzzy {
+    using TestUtilities for uint256[];
+
+    function setProjectSupply(address token, uint256 supply) internal override {
+        mockPool.setERC1155Supply(address(token), 1, supply);
+    }
+
+    function calculateDepositFees(
+        address pool,
+        address token,
+        uint256 amount
+    ) internal view override returns (FeeDistribution memory) {
+        return
+            feeCalculator.calculateDepositFees(
+                address(pool),
+                address(token),
+                1,
+                amount
+            );
+    }
+
+    function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public override {
+        vm.assume(total >= current);
+        vm.assume(depositAmount < 1e20 * 1e18);
+        vm.assume(depositAmount > 0);
+        vm.assume(total < 1e20 * 1e18);
+
+        // Arrange
+        // Set up your test data
+
+        // Set up mock pool
+        mockPool.setTotalSupply(total);
+        setProjectSupply(address(mockToken), current);
+
+        // Act
+        try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, depositAmount) {}
+        catch Error(string memory reason) {
+            assertTrue(
+                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+            );
+        }
+    }
+
+    function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(
+        uint8 numberOfDeposits,
+        uint256 depositAmount,
+        uint256 current,
+        uint256 total
+    ) public override {
+        vm.assume(0 < numberOfDeposits);
+        vm.assume(total >= current);
+
+        vm.assume(depositAmount < 1e20 * 1e18);
+        vm.assume(total < 1e20 * 1e18);
+
+        vm.assume(depositAmount > 1e-6 * 1e18);
+
+        // Arrange
+        // Set up your test data
+        bool oneTimeDepositFailed = false;
+        uint256 multipleTimesDepositFailedCount = 0;
+        // Set up mock pool
+        mockPool.setTotalSupply(total);
+        setProjectSupply(address(mockToken), current);
+
+        uint256 oneTimeFee = 0;
+
+        // Act
+        try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, depositAmount) returns (
+            FeeDistribution memory feeDistribution
+        ) {
+            oneTimeFee = feeDistribution.shares.sumOf();
+        } catch Error(string memory reason) {
+            oneTimeDepositFailed = true;
+            assertTrue(
+                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                    || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+            );
+        }
+
+        uint256 equalDeposit = depositAmount / numberOfDeposits;
+        uint256 restDeposit = depositAmount % numberOfDeposits;
+        uint256 feeFromDividedDeposits = 0;
+
+        for (uint256 i = 0; i < numberOfDeposits; i++) {
+            uint256 deposit = equalDeposit + (i == 0 ? restDeposit : 0);
+
+            try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, deposit) returns (
+                FeeDistribution memory feeDistribution
+            ) {
+                feeFromDividedDeposits += feeDistribution.shares.sumOf();
+                total += deposit;
+                current += deposit;
+                mockPool.setTotalSupply(total);
+                setProjectSupply(address(mockToken), current);
+            } catch Error(string memory reason) {
+                multipleTimesDepositFailedCount++;
+                assertTrue(
+                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
+                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                        || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                );
+            }
+        }
+
+        // Assert
+        if (multipleTimesDepositFailedCount == 0 && !oneTimeDepositFailed) {
+            uint256 maximumAllowedErrorPercentage = (numberOfDeposits <= 1) ? 0 : 2;
+            if (
+                oneTimeFee + feeFromDividedDeposits > 1e-8 * 1e18 // we skip assertion for extremely small fees (basically zero fees) because of numerical errors
+            ) {
+                assertGe((maximumAllowedErrorPercentage + 100) * feeFromDividedDeposits / 100, oneTimeFee);
+            } //we add 1% tolerance for numerical errors
+        }
+    }
+}

--- a/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsTCO2.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsTCO2.fuzzy.t.sol
@@ -10,23 +10,18 @@ import "./AbstractFeeCalculatorLaunchParams.fuzzy.t.sol";
 contract FeeCalculatorLaunchParamsTCO2TestFuzzy is AbstractFeeCalculatorLaunchParamsTestFuzzy {
     using TestUtilities for uint256[];
 
-        function setProjectSupply(address token, uint256 supply) internal override {
+    function setProjectSupply(address token, uint256 supply) internal override {
         mockPool.setTCO2Supply(address(token), supply);
     }
 
-    function calculateDepositFees(
-        address pool,
-        address token,
-        uint256 amount
-    ) internal view override returns (FeeDistribution memory) {
-        return
-            feeCalculator.calculateDepositFees(
-                address(pool),
-                address(token),
-                amount
-            );
+    function calculateDepositFees(address pool, address token, uint256 amount)
+        internal
+        view
+        override
+        returns (FeeDistribution memory)
+    {
+        return feeCalculator.calculateDepositFees(address(pool), address(token), amount);
     }
-
 
     function testCalculateDepositFeesFuzzy(uint256 depositAmount, uint256 current, uint256 total) public override {
         vm.assume(total >= current);

--- a/test/TestUtilities.sol
+++ b/test/TestUtilities.sol
@@ -22,8 +22,7 @@ library TestUtilities {
 contract MockPool is IERC20 {
     uint256 private _totalSupply;
     mapping(address => uint256) private _totalPerTCO2Supply;
-    mapping(address => mapping(uint256 => uint256))
-        private _totalPerERC1155TokenSupply;
+    mapping(address => mapping(uint256 => uint256)) private _totalPerERC1155TokenSupply;
 
     function totalSupply() external view returns (uint256) {
         return _totalSupply;
@@ -33,16 +32,11 @@ contract MockPool is IERC20 {
         return _totalSupply;
     }
 
-    function totalPerProjectSupply(
-        address tco2
-    ) external view returns (uint256) {
+    function totalPerProjectSupply(address tco2) external view returns (uint256) {
         return _totalPerTCO2Supply[tco2];
     }
 
-    function totalPerProjectSupply(
-        address erc1155,
-        uint256 tokenId
-    ) external view returns (uint256) {
+    function totalPerProjectSupply(address erc1155, uint256 tokenId) external view returns (uint256) {
         return _totalPerERC1155TokenSupply[erc1155][tokenId];
     }
 
@@ -58,10 +52,7 @@ contract MockPool is IERC20 {
         _totalPerERC1155TokenSupply[erc1155][tokenId] = ts;
     }
 
-    function allowance(
-        address,
-        address
-    ) external pure override returns (uint256) {
+    function allowance(address, address) external pure override returns (uint256) {
         return 0;
     }
 
@@ -73,11 +64,7 @@ contract MockPool is IERC20 {
         return true;
     }
 
-    function transferFrom(
-        address,
-        address,
-        uint256
-    ) external pure override returns (bool) {
+    function transferFrom(address, address, uint256) external pure override returns (bool) {
         return true;
     }
 
@@ -89,10 +76,7 @@ contract MockPool is IERC20 {
 contract MockToken is IERC20 {
     mapping(address => uint256) public override balanceOf;
 
-    function allowance(
-        address,
-        address
-    ) external pure override returns (uint256) {
+    function allowance(address, address) external pure override returns (uint256) {
         return 0;
     }
 
@@ -104,11 +88,7 @@ contract MockToken is IERC20 {
         return true;
     }
 
-    function transferFrom(
-        address,
-        address,
-        uint256
-    ) external pure override returns (bool) {
+    function transferFrom(address, address, uint256) external pure override returns (bool) {
         return true;
     }
 
@@ -117,20 +97,19 @@ contract MockToken is IERC20 {
     }
 
     function getVintageData() external pure returns (VintageData memory) {
-        return
-            VintageData({
-                name: "test",
-                startTime: 0,
-                endTime: 0,
-                projectTokenId: 1,
-                totalVintageQuantity: 0,
-                isCorsiaCompliant: false,
-                isCCPcompliant: false,
-                coBenefits: "",
-                correspAdjustment: "",
-                additionalCertification: "",
-                uri: "",
-                registry: ""
-            });
+        return VintageData({
+            name: "test",
+            startTime: 0,
+            endTime: 0,
+            projectTokenId: 1,
+            totalVintageQuantity: 0,
+            isCorsiaCompliant: false,
+            isCCPcompliant: false,
+            coBenefits: "",
+            correspAdjustment: "",
+            additionalCertification: "",
+            uri: "",
+            registry: ""
+        });
     }
 }

--- a/test/TestUtilities.sol
+++ b/test/TestUtilities.sol
@@ -21,7 +21,9 @@ library TestUtilities {
 
 contract MockPool is IERC20 {
     uint256 private _totalSupply;
-    mapping(uint256 => uint256) private _totalPerProjectSupply;
+    mapping(address => uint256) private _totalPerTCO2Supply;
+    mapping(address => mapping(uint256 => uint256))
+        private _totalPerERC1155TokenSupply;
 
     function totalSupply() external view returns (uint256) {
         return _totalSupply;
@@ -31,19 +33,35 @@ contract MockPool is IERC20 {
         return _totalSupply;
     }
 
-    function totalPerProjectTCO2Supply(uint256 projectTokenId) external view returns (uint256) {
-        return _totalPerProjectSupply[projectTokenId];
+    function totalPerProjectSupply(
+        address tco2
+    ) external view returns (uint256) {
+        return _totalPerTCO2Supply[tco2];
+    }
+
+    function totalPerProjectSupply(
+        address erc1155,
+        uint256 tokenId
+    ) external view returns (uint256) {
+        return _totalPerERC1155TokenSupply[erc1155][tokenId];
     }
 
     function setTotalSupply(uint256 ts) public {
         _totalSupply = ts;
     }
 
-    function setProjectSupply(uint256 projectTokenId, uint256 ts) public {
-        _totalPerProjectSupply[projectTokenId] = ts;
+    function setTCO2Supply(address tco2, uint256 ts) public {
+        _totalPerTCO2Supply[tco2] = ts;
     }
 
-    function allowance(address, address) external pure override returns (uint256) {
+    function setERC1155Supply(address erc1155, uint256 tokenId, uint256 ts) public {
+        _totalPerERC1155TokenSupply[erc1155][tokenId] = ts;
+    }
+
+    function allowance(
+        address,
+        address
+    ) external pure override returns (uint256) {
         return 0;
     }
 
@@ -55,7 +73,11 @@ contract MockPool is IERC20 {
         return true;
     }
 
-    function transferFrom(address, address, uint256) external pure override returns (bool) {
+    function transferFrom(
+        address,
+        address,
+        uint256
+    ) external pure override returns (bool) {
         return true;
     }
 
@@ -67,7 +89,10 @@ contract MockPool is IERC20 {
 contract MockToken is IERC20 {
     mapping(address => uint256) public override balanceOf;
 
-    function allowance(address, address) external pure override returns (uint256) {
+    function allowance(
+        address,
+        address
+    ) external pure override returns (uint256) {
         return 0;
     }
 
@@ -79,7 +104,11 @@ contract MockToken is IERC20 {
         return true;
     }
 
-    function transferFrom(address, address, uint256) external pure override returns (bool) {
+    function transferFrom(
+        address,
+        address,
+        uint256
+    ) external pure override returns (bool) {
         return true;
     }
 
@@ -88,19 +117,20 @@ contract MockToken is IERC20 {
     }
 
     function getVintageData() external pure returns (VintageData memory) {
-        return VintageData({
-            name: "test",
-            startTime: 0,
-            endTime: 0,
-            projectTokenId: 1,
-            totalVintageQuantity: 0,
-            isCorsiaCompliant: false,
-            isCCPcompliant: false,
-            coBenefits: "",
-            correspAdjustment: "",
-            additionalCertification: "",
-            uri: "",
-            registry: ""
-        });
+        return
+            VintageData({
+                name: "test",
+                startTime: 0,
+                endTime: 0,
+                projectTokenId: 1,
+                totalVintageQuantity: 0,
+                isCorsiaCompliant: false,
+                isCCPcompliant: false,
+                coBenefits: "",
+                correspAdjustment: "",
+                additionalCertification: "",
+                uri: "",
+                registry: ""
+            });
     }
 }


### PR DESCRIPTION
- Add support for ERC1155 projects
- Move project supply retrieval completely on the Pool (IPool modified accordingly, further PR on tokenizer will follow)
- Refactor `FeeCalculator` private and internal methods