### PR TITLE
Revert #55

### DIFF
--- a/src/FlatFeeCalculator.sol
+++ b/src/FlatFeeCalculator.sol
@@ -24,12 +24,6 @@ contract FlatFeeCalculator is IFeeCalculator, Ownable {
 
     uint256 public feeBasisPoints = 300;
 
-    /// @dev The scale between the decimals of the fee token and the underlying token.
-    /// For example, if the fee token has 18 decimals and the underlying token has 18 decimals, the
-    /// decimals scale is 1e0.
-    /// If the fee token has 18 decimals and the underlying token has 0 decimals, the decimals scale is 1e18
-    uint256 public feeToUnderlyingDecimalsScale = 1e18;
-
     address[] private _recipients;
     uint256[] private _shares;
 
@@ -37,12 +31,6 @@ contract FlatFeeCalculator is IFeeCalculator, Ownable {
     event FeeSetup(address[] recipients, uint256[] shares);
 
     constructor() Ownable() {}
-
-    function setFeeToUnderlyingDecimalsScale(uint256 _feeToUnderlyingDecimalsScale) external onlyOwner {
-        require(_feeToUnderlyingDecimalsScale != 0, "Fee to underlying decimals scale must be greater than 0");
-
-        feeToUnderlyingDecimalsScale = _feeToUnderlyingDecimalsScale;
-    }
 
     /// @notice Sets the fee basis points.
     /// @dev Can only be called by the current owner.
@@ -169,10 +157,9 @@ contract FlatFeeCalculator is IFeeCalculator, Ownable {
     function _calculateFee(uint256 requestedAmount) internal view returns (FeeDistribution memory) {
         require(requestedAmount != 0, "requested amount must be > 0");
 
-        uint256 adjustedAmount = requestedAmount * feeToUnderlyingDecimalsScale;
-        uint256 feeAmount = adjustedAmount * feeBasisPoints / 10000;
+        uint256 feeAmount = requestedAmount * feeBasisPoints / 10000;
 
-        require(feeAmount <= adjustedAmount, "Fee must be lower or equal to requested amount");
+        require(feeAmount <= requestedAmount, "Fee must be lower or equal to requested amount");
         require(feeAmount != 0, "Fee must be greater than 0");
 
         return calculateFeeShares(feeAmount);

--- a/src/FlatFeeCalculator.sol
+++ b/src/FlatFeeCalculator.sol
@@ -158,8 +158,6 @@ contract FlatFeeCalculator is IFeeCalculator, Ownable {
         require(requestedAmount != 0, "requested amount must be > 0");
 
         uint256 feeAmount = requestedAmount * feeBasisPoints / 10000;
-
-        require(feeAmount <= requestedAmount, "Fee must be lower or equal to requested amount");
         require(feeAmount != 0, "Fee must be greater than 0");
 
         return calculateFeeShares(feeAmount);

--- a/test/FlatFeeCalculatorFuzzy/FlatFeeCalculator.fuzzy.t.sol
+++ b/test/FlatFeeCalculatorFuzzy/FlatFeeCalculator.fuzzy.t.sol
@@ -22,7 +22,6 @@ contract FlatFeeCalculatorTestFuzzy is Test {
         uint256[] memory feeShares = new uint256[](1);
         feeShares[0] = 100;
         feeCalculator.feeSetup(recipients, feeShares);
-        feeCalculator.setFeeToUnderlyingDecimalsScale(1);
     }
 
     function testFeeSetupEmpty() public {
@@ -152,21 +151,6 @@ contract FlatFeeCalculatorTestFuzzy is Test {
         assertEq(feeDistribution.shares[0], expected);
     }
 
-    function testCalculateDepositFee_withFeeToUnderlyingScale_TCO2(uint256 depositAmount) public {
-        // Arrange
-        vm.assume(depositAmount > 1);
-        vm.assume(depositAmount < 1e18);
-
-        uint256 feeToUnderlyingDecimalsScale = 1e18;
-        feeCalculator.setFeeToUnderlyingDecimalsScale(feeToUnderlyingDecimalsScale);
-        // Act
-        FeeDistribution memory feeDistribution = feeCalculator.calculateDepositFees(empty, empty, depositAmount);
-
-        uint256 expected = depositAmount * feeToUnderlyingDecimalsScale * feeCalculator.feeBasisPoints() / 10000;
-
-        assertEq(feeDistribution.shares[0], expected);
-    }
-
     function testCalculateDepositFee_ERC1155(uint256 depositAmount) public {
         // Arrange
         vm.assume(depositAmount > 100);
@@ -175,21 +159,6 @@ contract FlatFeeCalculatorTestFuzzy is Test {
         FeeDistribution memory feeDistribution = feeCalculator.calculateDepositFees(empty, empty, 0, depositAmount);
 
         uint256 expected = depositAmount * feeCalculator.feeBasisPoints() / 10000;
-
-        assertEq(feeDistribution.shares[0], expected);
-    }
-
-    function testCalculateDepositFee_withFeeToUnderlyingScale_ERC1155(uint256 depositAmount) public {
-        // Arrange
-        vm.assume(depositAmount > 1);
-        vm.assume(depositAmount < 1e18);
-
-        uint256 feeToUnderlyingDecimalsScale = 1e18;
-        feeCalculator.setFeeToUnderlyingDecimalsScale(feeToUnderlyingDecimalsScale);
-        // Act
-        FeeDistribution memory feeDistribution = feeCalculator.calculateDepositFees(empty, empty, 0, depositAmount);
-
-        uint256 expected = depositAmount * feeToUnderlyingDecimalsScale * feeCalculator.feeBasisPoints() / 10000;
 
         assertEq(feeDistribution.shares[0], expected);
     }
@@ -220,39 +189,6 @@ contract FlatFeeCalculatorTestFuzzy is Test {
 
         uint256 expected =
             (redemptionAmount1 + redemptionAmount2 + redemptionAmount3) * feeCalculator.feeBasisPoints() / 10000;
-
-        assertEq(feeDistribution.shares[0], expected);
-    }
-
-    function testCalculateRedemptionAmount_withFeeToUnderlyingScale_TCO2(
-        uint256 redemptionAmount1,
-        uint256 redemptionAmount2,
-        uint256 redemptionAmount3
-    ) public {
-        // Arrange
-        vm.assume(redemptionAmount1 > 100);
-        vm.assume(redemptionAmount1 < 1e18 * 1e18);
-        vm.assume(redemptionAmount2 > 100);
-        vm.assume(redemptionAmount2 < 1e18 * 1e18);
-        vm.assume(redemptionAmount3 > 100);
-        vm.assume(redemptionAmount3 < 1e18 * 1e18);
-
-        uint256 feeToUnderlyingDecimalsScale = 1e18;
-        feeCalculator.setFeeToUnderlyingDecimalsScale(feeToUnderlyingDecimalsScale);
-        // Act
-        address[] memory tco2s = new address[](3);
-        tco2s[0] = empty;
-        tco2s[1] = empty;
-        tco2s[2] = empty;
-        uint256[] memory redemptionAmounts = new uint256[](3);
-        redemptionAmounts[0] = redemptionAmount1;
-        redemptionAmounts[1] = redemptionAmount2;
-        redemptionAmounts[2] = redemptionAmount3;
-
-        FeeDistribution memory feeDistribution = feeCalculator.calculateRedemptionFees(empty, tco2s, redemptionAmounts);
-
-        uint256 expected = (redemptionAmount1 + redemptionAmount2 + redemptionAmount3) * feeToUnderlyingDecimalsScale
-            * feeCalculator.feeBasisPoints() / 10000;
 
         assertEq(feeDistribution.shares[0], expected);
     }
@@ -288,44 +224,6 @@ contract FlatFeeCalculatorTestFuzzy is Test {
 
         uint256 expected =
             (redemptionAmount1 + redemptionAmount2 + redemptionAmount3) * feeCalculator.feeBasisPoints() / 10000;
-
-        assertEq(feeDistribution.shares[0], expected);
-    }
-
-    function testCalculateRedemptionAmount_withFeeToUnderlyingScale_ERC1155(
-        uint256 redemptionAmount1,
-        uint256 redemptionAmount2,
-        uint256 redemptionAmount3
-    ) public {
-        // Arrange
-        vm.assume(redemptionAmount1 > 100);
-        vm.assume(redemptionAmount1 < 1e18 * 1e18);
-        vm.assume(redemptionAmount2 > 100);
-        vm.assume(redemptionAmount2 < 1e18 * 1e18);
-        vm.assume(redemptionAmount3 > 100);
-        vm.assume(redemptionAmount3 < 1e18 * 1e18);
-
-        uint256 feeToUnderlyingDecimalsScale = 1e18;
-        feeCalculator.setFeeToUnderlyingDecimalsScale(feeToUnderlyingDecimalsScale);
-        // Act
-        address[] memory erc1155s = new address[](3);
-        erc1155s[0] = empty;
-        erc1155s[1] = empty;
-        erc1155s[2] = empty;
-        uint256[] memory tokenIds = new uint256[](3);
-        tokenIds[0] = 1;
-        tokenIds[1] = 2;
-        tokenIds[2] = 3;
-        uint256[] memory redemptionAmounts = new uint256[](3);
-        redemptionAmounts[0] = redemptionAmount1;
-        redemptionAmounts[1] = redemptionAmount2;
-        redemptionAmounts[2] = redemptionAmount3;
-
-        FeeDistribution memory feeDistribution =
-            feeCalculator.calculateRedemptionFees(empty, erc1155s, tokenIds, redemptionAmounts);
-
-        uint256 expected = (redemptionAmount1 + redemptionAmount2 + redemptionAmount3) * feeToUnderlyingDecimalsScale
-            * feeCalculator.feeBasisPoints() / 10000;
 
         assertEq(feeDistribution.shares[0], expected);
     }


### PR DESCRIPTION
Revert https://github.com/ToucanProtocol/dynamic-fee-pools/pull/55 since the underlying decimals conversion does not need to happen at the calculator and it's currently handled by the pool.