### PR TITLE
[LILA-7980]  Do not throw on zero fee returned

### DIFF
--- a/src/FeeCalculator.sol
+++ b/src/FeeCalculator.sol
@@ -20,7 +20,7 @@ contract FeeCalculator is IFeeCalculator, Ownable {
     /// @dev Version-related parameters. VERSION keeps track of production
     /// releases. VERSION_RELEASE_CANDIDATE keeps track of iterations
     /// of a VERSION in our staging environment.
-    string public constant VERSION = "1.1.0";
+    string public constant VERSION = "1.2.0";
     uint256 public constant VERSION_RELEASE_CANDIDATE = 1;
 
     SD59x18 private _zero = sd(0);
@@ -406,7 +406,9 @@ contract FeeCalculator is IFeeCalculator, Ownable {
         uint256 feeAmount = calculator(requestedAmount, projectSupply, totalPoolSupply);
 
         require(feeAmount <= requestedAmount, "Fee must be lower or equal to requested amount");
-        require(feeAmount != 0, "Fee must be greater than 0");
+        if (feeAmount == 0) {
+            return FeeDistribution(new address[](0), new uint256[](0));
+        }
 
         return calculateFeeShares(feeAmount);
     }

--- a/src/FlatFeeCalculator.sol
+++ b/src/FlatFeeCalculator.sol
@@ -19,7 +19,7 @@ contract FlatFeeCalculator is IFeeCalculator, Ownable {
     /// @dev Version-related parameters. VERSION keeps track of production
     /// releases. VERSION_RELEASE_CANDIDATE keeps track of iterations
     /// of a VERSION in our staging environment.
-    string public constant VERSION = "1.0.0";
+    string public constant VERSION = "1.1.0";
     uint256 public constant VERSION_RELEASE_CANDIDATE = 2;
 
     uint256 public feeBasisPoints = 300;
@@ -158,7 +158,9 @@ contract FlatFeeCalculator is IFeeCalculator, Ownable {
         require(requestedAmount != 0, "requested amount must be > 0");
 
         uint256 feeAmount = requestedAmount * feeBasisPoints / 10000;
-        require(feeAmount != 0, "Fee must be greater than 0");
+        if (feeAmount == 0) {
+            return FeeDistribution(new address[](0), new uint256[](0));
+        }
 
         return calculateFeeShares(feeAmount);
     }

--- a/test/FeeCalculator/AbstractFeeCalculator.t.sol
+++ b/test/FeeCalculator/AbstractFeeCalculator.t.sol
@@ -254,7 +254,7 @@ abstract contract AbstractFeeCalculatorTest is Test {
         assertEq(fees[0], 46413457506542766270);
     }
 
-    function testCalculateDepositFees_DepositOfOneWei_ShouldThrowException() public {
+    function testCalculateDepositFees_DepositOfOneWei_ShouldNotThrowException() public {
         // Arrange
         // Set up your test data
         uint256 depositAmount = 1;
@@ -264,11 +264,13 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
-        vm.expectRevert("Fee must be greater than 0");
-        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
-    function testCalculateDepositFees_DepositOfHundredWei_ShouldThrowError() public {
+    function testCalculateDepositFees_DepositOfHundredWei_ShouldNotThrowError() public {
         //Note! This is a bug, where a very small deposit to a very large pool
         //causes a == b because of precision limited by ratioDenominator in FeeCalculator
 
@@ -281,8 +283,10 @@ abstract contract AbstractFeeCalculatorTest is Test {
         setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
-        vm.expectRevert("Fee must be greater than 0");
-        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
     function testCalculateDepositFees_DepositOfHundredThousandsPartOfOne_NonzeroFee() public {

--- a/test/FeeCalculatorFuzzy/AbstractFeeCalculator.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/AbstractFeeCalculator.fuzzy.t.sol
@@ -50,7 +50,7 @@ abstract contract AbstractFeeCalculatorTestFuzzy is Test {
         uint256 total
     ) public virtual;
 
-    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldThrowError(uint256 depositAmount)
+    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldNotThrowError(uint256 depositAmount)
         public
     {
         vm.assume(depositAmount <= 1e-14 * 1e18);
@@ -66,8 +66,10 @@ abstract contract AbstractFeeCalculatorTestFuzzy is Test {
         mockPool.setTotalSupply(1e12 * 1e18);
         setProjectSupply(address(mockToken), 1e9 * 1e18);
 
-        vm.expectRevert("Fee must be greater than 0");
-        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
     function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoOneChunkFeesGreaterOrEqualToOneRedemption(

--- a/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
@@ -43,9 +43,8 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, depositAmount) {}
         catch Error(string memory reason) {
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be lower or equal to requested amount'"
             );
         }
     }
@@ -95,9 +94,8 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         } catch Error(string memory reason) {
             oneTimeRedemptionFailed = true;
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be lower or equal to requested amount'"
             );
         }
 
@@ -125,9 +123,8 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
             } catch Error(string memory reason) {
                 multipleTimesRedemptionFailedCount++;
                 assertTrue(
-                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                    keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be lower or equal to requested amount'"
                 );
             }
         }
@@ -168,9 +165,8 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         } catch Error(string memory reason) {
             oneTimeDepositFailed = true;
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be lower or equal to requested amount'"
             );
         }
 
@@ -192,9 +188,8 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(
-                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                    keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be lower or equal to requested amount'"
                 );
             }
         }

--- a/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
@@ -40,9 +40,8 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount) {}
         catch Error(string memory reason) {
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be lower or equal to requested amount'"
             );
         }
     }
@@ -90,9 +89,8 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         } catch Error(string memory reason) {
             oneTimeRedemptionFailed = true;
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be lower or equal to requested amount'"
             );
         }
 
@@ -120,9 +118,8 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
             } catch Error(string memory reason) {
                 multipleTimesRedemptionFailedCount++;
                 assertTrue(
-                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                    keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be lower or equal to requested amount'"
                 );
             }
         }
@@ -163,9 +160,8 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         } catch Error(string memory reason) {
             oneTimeDepositFailed = true;
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                "error should be 'Fee must be lower or equal to requested amount'"
             );
         }
 
@@ -187,9 +183,8 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(
-                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount'"
+                    keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
+                    "error should be 'Fee must be lower or equal to requested amount'"
                 );
             }
         }

--- a/test/FeeCalculatorLaunchParams/AbstractFeeCalculatorLaunchParams.t.sol
+++ b/test/FeeCalculatorLaunchParams/AbstractFeeCalculatorLaunchParams.t.sol
@@ -147,7 +147,7 @@ abstract contract AbstractFeeCalculatorLaunchParamsTest is Test {
         assertEq(fees[0], 53013879215838797358);
     }
 
-    function testCalculateDepositFees_DepositOfOneWei_ShouldThrowException() public {
+    function testCalculateDepositFees_DepositOfOneWei_ShouldNotThrowException() public {
         // Arrange
         // Set up your test data
         uint256 depositAmount = 1;
@@ -157,11 +157,13 @@ abstract contract AbstractFeeCalculatorLaunchParamsTest is Test {
         setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
-        vm.expectRevert("Fee must be greater than 0");
-        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
-    function testCalculateDepositFees_DepositOfHundredWei_ShouldThrowError() public {
+    function testCalculateDepositFees_DepositOfHundredWei_ShouldNotThrowError() public {
         //Note! This is a bug, where a very small deposit to a very large pool
         //causes a == b because of precision limited by ratioDenominator in FeeCalculator
 
@@ -174,8 +176,10 @@ abstract contract AbstractFeeCalculatorLaunchParamsTest is Test {
         setProjectSupply(address(mockToken), 1e4 * 1e18);
 
         // Act
-        vm.expectRevert("Fee must be greater than 0");
-        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
     function testCalculateDepositFees_DepositOfHundredThousandsPartOfOne_NonzeroFee() public {

--- a/test/FeeCalculatorLaunchParamsFuzzy/AbstractFeeCalculatorLaunchParams.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/AbstractFeeCalculatorLaunchParams.fuzzy.t.sol
@@ -47,7 +47,7 @@ abstract contract AbstractFeeCalculatorLaunchParamsTestFuzzy is Test {
         uint256 total
     ) public virtual;
 
-    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldThrowError(uint256 depositAmount)
+    function testCalculateDepositFees_FuzzyExtremelySmallDepositsToLargePool_ShouldNotThrowError(uint256 depositAmount)
         public
     {
         vm.assume(depositAmount <= 1e-14 * 1e18);
@@ -63,8 +63,10 @@ abstract contract AbstractFeeCalculatorLaunchParamsTestFuzzy is Test {
         mockPool.setTotalSupply(1e12 * 1e18);
         setProjectSupply(address(mockToken), 1e9 * 1e18);
 
-        vm.expectRevert("Fee must be greater than 0");
-        calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        FeeDistribution memory feeDistribution =
+            calculateDepositFees(address(mockPool), address(mockToken), depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoOneChunkFeesGreaterOrEqualToOneDeposit(

--- a/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsERC1155.fuzzy.t.sol
@@ -40,10 +40,9 @@ contract FeeCalculatorLaunchParamsERC1155TestFuzzy is AbstractFeeCalculatorLaunc
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), 1, depositAmount) {}
         catch Error(string memory reason) {
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
                     || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                "error should be 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
             );
         }
     }
@@ -80,10 +79,9 @@ contract FeeCalculatorLaunchParamsERC1155TestFuzzy is AbstractFeeCalculatorLaunc
         } catch Error(string memory reason) {
             oneTimeDepositFailed = true;
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
                     || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                "error should be 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
             );
         }
 
@@ -105,10 +103,9 @@ contract FeeCalculatorLaunchParamsERC1155TestFuzzy is AbstractFeeCalculatorLaunc
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(
-                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                    keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
                         || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                    "error should be 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
                 );
             }
         }

--- a/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsTCO2.fuzzy.t.sol
+++ b/test/FeeCalculatorLaunchParamsFuzzy/FeeCalculatorLaunchParamsTCO2.fuzzy.t.sol
@@ -40,10 +40,9 @@ contract FeeCalculatorLaunchParamsTCO2TestFuzzy is AbstractFeeCalculatorLaunchPa
         try feeCalculator.calculateDepositFees(address(mockPool), address(mockToken), depositAmount) {}
         catch Error(string memory reason) {
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
                     || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                "error should be 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
             );
         }
     }
@@ -80,10 +79,9 @@ contract FeeCalculatorLaunchParamsTCO2TestFuzzy is AbstractFeeCalculatorLaunchPa
         } catch Error(string memory reason) {
             oneTimeDepositFailed = true;
             assertTrue(
-                keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                    || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
                     || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
-                "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                "error should be 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
             );
         }
 
@@ -105,10 +103,9 @@ contract FeeCalculatorLaunchParamsTCO2TestFuzzy is AbstractFeeCalculatorLaunchPa
             } catch Error(string memory reason) {
                 multipleTimesDepositFailedCount++;
                 assertTrue(
-                    keccak256(bytes("Fee must be greater than 0")) == keccak256(bytes(reason))
-                        || keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
+                    keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason))
                         || keccak256(bytes("Deposit outside range")) == keccak256(bytes(reason)),
-                    "error should be 'Fee must be greater than 0' or 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
+                    "error should be 'Fee must be lower or equal to requested amount' or 'Deposit outside range'"
                 );
             }
         }

--- a/test/FlatFeeCalculatorFuzzy/FlatFeeCalculator.fuzzy.t.sol
+++ b/test/FlatFeeCalculatorFuzzy/FlatFeeCalculator.fuzzy.t.sol
@@ -129,14 +129,15 @@ contract FlatFeeCalculatorTestFuzzy is Test {
         assertEq(fees[0], expected);
     }
 
-    function testCalculateRedemptionFeesDustAmount_ShouldThrow() public {
+    function testCalculateRedemptionFeesDustAmount_ShouldNotThrow() public {
         // Arrange
         // Set up your test data
         uint256 depositAmount = 1;
 
         // Act
-        vm.expectRevert("Fee must be greater than 0");
-        feeCalculator.calculateDepositFees(empty, empty, depositAmount);
+        FeeDistribution memory feeDistribution = feeCalculator.calculateDepositFees(empty, empty, depositAmount);
+        assertEq(feeDistribution.recipients.length, 0);
+        assertEq(feeDistribution.shares.length, 0);
     }
 
     function testCalculateDepositFee_TCO2(uint256 depositAmount) public {


### PR DESCRIPTION
There can be edge cases in the pool where the pool may provide one or more wei in the calculation
functions and the calculation functions return zero.

For example, this can happen when CHAR is using a
new feature called `minimumTCLSeedingThreshold` that:
1. avoids charging fees to deposits that keep the total underlying supply below a certain threshold
2. charges fees partially when the deposit brings the total underlying supply above the threshold
3. charges fees normally above the threshold

Given a deposit that falls under 2, it may be that the chargeable amount is one or more few wei. In this scenario, the pool currently has to handle an error returned by the fee calculator which decreases devexp and complicates pool code.

On the other hand, the pool code is already written to loop through the returned arrays that are part of the FeeDistribution struct so returning a struct with empty arrays means this edge case can be handled in the pool seamlessly.