### PR TITLE
[LILA-7980] Remove viaIR dependency from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
-          forge build --sizes --via-ir
+          forge build --sizes
         id: build
 
       - name: Check formatting
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv --via-ir
+          forge test -vvv
         id: test
 
       - name: Install Slither

--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ Run the following command in your terminal:
 
 all tests
 ```bash
-forge test -vv --via-ir
+forge test -vv
 ```
 
 basic tests only
 ```bash
-forge test --no-match-contract Fuzzy -vv --via-ir
+forge test --no-match-contract Fuzzy -vv
 ```
 
 fuzzy tests only
 ```bash
-forge test --match-contract Fuzzy -vv --via-ir
+forge test --match-contract Fuzzy -vv
 ```
 
 
@@ -126,15 +126,13 @@ Remember, the goal is to maintain a balanced pool composition and discourage mon
 
 1. Deploy the contract:
 
-    forge create --via-ir                    \
-                 --rpc-url <rpc-url>         \
+    forge create --rpc-url <rpc-url>         \
                  --private-key <private-key> \
                 FeeCalculator
 
 Optionally, if you want to verify the contract at the same time:
 
-    forge create --via-ir                            \
-                 --rpc-url <rpc-url>                 \
+    forge create --rpc-url <rpc-url>                 \
                  --private-key <private-key>         \
                  --etherscan-api-key <etherscan-key> \
                  --verify                            \

--- a/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorERC1155.fuzzy.t.sol
@@ -49,6 +49,23 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         }
     }
 
+    struct FuzzCalculationArgs {
+        uint8 numberOfRedemptions;
+        uint256 redemptionAmount;
+        uint256 current;
+        uint256 total;
+        SD59x18 dustAssetRedemptionRelativeFee;
+        uint256 oneTimeFee;
+        bool oneTimeRedemptionFailed;
+        uint256 multipleTimesRedemptionFailedCount;
+        address[] tco2s;
+        uint256[] tokenIds;
+        uint256[] redemptionAmounts;
+        uint256 equalRedemption;
+        uint256 restRedemption;
+        uint256 feeFromDividedRedemptions;
+    }
+
     function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
         uint8 numberOfRedemptions,
         uint128 _redemptionAmount,
@@ -63,36 +80,40 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         vm.assume(_redemptionAmount > 1e-6 * 1e18);
         vm.assume(_current > 1e12);
 
-        uint256 redemptionAmount = _redemptionAmount;
-        uint256 current = _current;
-        uint256 total = _total;
-
-        SD59x18 dustAssetRedemptionRelativeFee = sd(0.3 * 1e18);
-
         // Arrange
         // Set up your test data
 
-        // Set up mock pool
-        mockPool.setTotalSupply(total);
-        setProjectSupply(address(mockToken), current);
-        uint256 oneTimeFee = 0;
-        bool oneTimeRedemptionFailed = false;
-        uint256 multipleTimesRedemptionFailedCount = 0;
+        FuzzCalculationArgs memory args = FuzzCalculationArgs({
+            numberOfRedemptions: numberOfRedemptions,
+            redemptionAmount: uint128(_redemptionAmount),
+            current: uint128(_current),
+            total: uint128(_total),
+            dustAssetRedemptionRelativeFee: sd(0.3 * 1e18),
+            oneTimeFee: 0,
+            oneTimeRedemptionFailed: false,
+            multipleTimesRedemptionFailedCount: 0,
+            tco2s: new address[](1),
+            tokenIds: new uint256[](1),
+            redemptionAmounts: new uint256[](1),
+            equalRedemption: 0,
+            restRedemption: 0,
+            feeFromDividedRedemptions: 0
+        });
 
-        address[] memory tco2s = new address[](1);
-        tco2s[0] = address(mockToken);
-        uint256[] memory tokenIds = new uint256[](1);
-        tokenIds[0] = 1;
-        uint256[] memory redemptionAmounts = new uint256[](1);
-        redemptionAmounts[0] = redemptionAmount;
+        // Set up mock pool
+        mockPool.setTotalSupply(args.total);
+        setProjectSupply(address(mockToken), args.current);
+
+        args.tco2s[0] = address(mockToken);
+        args.tokenIds[0] = 1;
+        args.redemptionAmounts[0] = args.redemptionAmount;
 
         // Act
-        try feeCalculator.calculateRedemptionFees(address(mockPool), tco2s, tokenIds, redemptionAmounts) returns (
-            FeeDistribution memory feeDistribution
-        ) {
-            oneTimeFee = feeDistribution.shares.sumOf();
+        try feeCalculator.calculateRedemptionFees(address(mockPool), args.tco2s, args.tokenIds, args.redemptionAmounts)
+        returns (FeeDistribution memory feeDistribution) {
+            args.oneTimeFee = feeDistribution.shares.sumOf();
         } catch Error(string memory reason) {
-            oneTimeRedemptionFailed = true;
+            args.oneTimeRedemptionFailed = true;
             assertTrue(
                 keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
                 "error should be 'Fee must be lower or equal to requested amount'"
@@ -100,28 +121,29 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         }
 
         /// @dev if we fail at the first try, we do not want to test the rest of the function
-        vm.assume(oneTimeRedemptionFailed == false);
+        vm.assume(args.oneTimeRedemptionFailed == false);
         /// @dev This prevents the case when the fee is so small that it is being calculated using dustAssetRedemptionRelativeFee
         /// @dev we don not want to test this case
-        vm.assume(oneTimeFee != sdIntoUint256(sd(int256(redemptionAmount)) * dustAssetRedemptionRelativeFee));
+        vm.assume(
+            args.oneTimeFee != sdIntoUint256(sd(int256(args.redemptionAmount)) * args.dustAssetRedemptionRelativeFee)
+        );
 
-        uint256 equalRedemption = redemptionAmount / numberOfRedemptions;
-        uint256 restRedemption = redemptionAmount % numberOfRedemptions;
-        uint256 feeFromDividedRedemptions = 0;
+        args.equalRedemption = args.redemptionAmount / args.numberOfRedemptions;
+        args.restRedemption = args.redemptionAmount % args.numberOfRedemptions;
 
-        for (uint256 i = 0; i < numberOfRedemptions; i++) {
-            uint256 redemption = equalRedemption + (i == 0 ? restRedemption : 0);
-            redemptionAmounts[0] = redemption;
-            try feeCalculator.calculateRedemptionFees(address(mockPool), tco2s, tokenIds, redemptionAmounts) returns (
-                FeeDistribution memory feeDistribution
-            ) {
-                feeFromDividedRedemptions += feeDistribution.shares.sumOf();
-                total -= redemption;
-                current -= redemption;
-                mockPool.setTotalSupply(total);
-                setProjectSupply(address(mockToken), current);
+        for (uint256 i = 0; i < args.numberOfRedemptions; i++) {
+            uint256 redemption = args.equalRedemption + (i == 0 ? args.restRedemption : 0);
+            args.redemptionAmounts[0] = redemption;
+            try feeCalculator.calculateRedemptionFees(
+                address(mockPool), args.tco2s, args.tokenIds, args.redemptionAmounts
+            ) returns (FeeDistribution memory feeDistribution) {
+                args.feeFromDividedRedemptions += feeDistribution.shares.sumOf();
+                args.total -= redemption;
+                args.current -= redemption;
+                mockPool.setTotalSupply(args.total);
+                setProjectSupply(address(mockToken), args.current);
             } catch Error(string memory reason) {
-                multipleTimesRedemptionFailedCount++;
+                args.multipleTimesRedemptionFailedCount++;
                 assertTrue(
                     keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
                     "error should be 'Fee must be lower or equal to requested amount'"
@@ -130,7 +152,7 @@ contract FeeCalculatorERC1155TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         }
 
         // @dev we allow for 0.1% error
-        assertGe(1001 * feeFromDividedRedemptions / 1000, oneTimeFee);
+        assertGe(1001 * args.feeFromDividedRedemptions / 1000, args.oneTimeFee);
     }
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(

--- a/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
+++ b/test/FeeCalculatorFuzzy/FeeCalculatorTCO2.fuzzy.t.sol
@@ -46,6 +46,22 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         }
     }
 
+    struct FuzzCalculationArgs {
+        uint8 numberOfRedemptions;
+        uint256 redemptionAmount;
+        uint256 current;
+        uint256 total;
+        SD59x18 dustAssetRedemptionRelativeFee;
+        uint256 oneTimeFee;
+        bool oneTimeRedemptionFailed;
+        uint256 multipleTimesRedemptionFailedCount;
+        address[] tco2s;
+        uint256[] redemptionAmounts;
+        uint256 equalRedemption;
+        uint256 restRedemption;
+        uint256 feeFromDividedRedemptions;
+    }
+
     function testCalculateRedemptionFeesFuzzy_RedemptionDividedIntoMultipleChunksFeesGreaterOrEqualToOneRedemption(
         uint8 numberOfRedemptions,
         uint128 _redemptionAmount,
@@ -60,34 +76,39 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         vm.assume(_redemptionAmount > 1e-6 * 1e18);
         vm.assume(_current > 1e12);
 
-        uint256 redemptionAmount = _redemptionAmount;
-        uint256 current = _current;
-        uint256 total = _total;
-
-        SD59x18 dustAssetRedemptionRelativeFee = sd(0.3 * 1e18);
-
         // Arrange
         // Set up your test data
 
-        // Set up mock pool
-        mockPool.setTotalSupply(total);
-        setProjectSupply(address(mockToken), current);
-        uint256 oneTimeFee = 0;
-        bool oneTimeRedemptionFailed = false;
-        uint256 multipleTimesRedemptionFailedCount = 0;
+        FuzzCalculationArgs memory args = FuzzCalculationArgs({
+            numberOfRedemptions: numberOfRedemptions,
+            redemptionAmount: uint128(_redemptionAmount),
+            current: uint128(_current),
+            total: uint128(_total),
+            dustAssetRedemptionRelativeFee: sd(0.3 * 1e18),
+            oneTimeFee: 0,
+            oneTimeRedemptionFailed: false,
+            multipleTimesRedemptionFailedCount: 0,
+            tco2s: new address[](1),
+            redemptionAmounts: new uint256[](1),
+            equalRedemption: 0,
+            restRedemption: 0,
+            feeFromDividedRedemptions: 0
+        });
 
-        address[] memory tco2s = new address[](1);
-        tco2s[0] = address(mockToken);
-        uint256[] memory redemptionAmounts = new uint256[](1);
-        redemptionAmounts[0] = redemptionAmount;
+        // Set up mock pool
+        mockPool.setTotalSupply(args.total);
+        setProjectSupply(address(mockToken), args.current);
+
+        args.tco2s[0] = address(mockToken);
+        args.redemptionAmounts[0] = args.redemptionAmount;
 
         // Act
-        try feeCalculator.calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts) returns (
+        try feeCalculator.calculateRedemptionFees(address(mockPool), args.tco2s, args.redemptionAmounts) returns (
             FeeDistribution memory feeDistribution
         ) {
-            oneTimeFee = feeDistribution.shares.sumOf();
+            args.oneTimeFee = feeDistribution.shares.sumOf();
         } catch Error(string memory reason) {
-            oneTimeRedemptionFailed = true;
+            args.oneTimeRedemptionFailed = true;
             assertTrue(
                 keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
                 "error should be 'Fee must be lower or equal to requested amount'"
@@ -95,28 +116,29 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         }
 
         /// @dev if we fail at the first try, we do not want to test the rest of the function
-        vm.assume(oneTimeRedemptionFailed == false);
+        vm.assume(args.oneTimeRedemptionFailed == false);
         /// @dev This prevents the case when the fee is so small that it is being calculated using dustAssetRedemptionRelativeFee
         /// @dev we don not want to test this case
-        vm.assume(oneTimeFee != sdIntoUint256(sd(int256(redemptionAmount)) * dustAssetRedemptionRelativeFee));
+        vm.assume(
+            args.oneTimeFee != sdIntoUint256(sd(int256(args.redemptionAmount)) * args.dustAssetRedemptionRelativeFee)
+        );
 
-        uint256 equalRedemption = redemptionAmount / numberOfRedemptions;
-        uint256 restRedemption = redemptionAmount % numberOfRedemptions;
-        uint256 feeFromDividedRedemptions = 0;
+        args.equalRedemption = args.redemptionAmount / args.numberOfRedemptions;
+        args.restRedemption = args.redemptionAmount % args.numberOfRedemptions;
 
-        for (uint256 i = 0; i < numberOfRedemptions; i++) {
-            uint256 redemption = equalRedemption + (i == 0 ? restRedemption : 0);
-            redemptionAmounts[0] = redemption;
-            try feeCalculator.calculateRedemptionFees(address(mockPool), tco2s, redemptionAmounts) returns (
+        for (uint256 i = 0; i < args.numberOfRedemptions; i++) {
+            uint256 redemption = args.equalRedemption + (i == 0 ? args.restRedemption : 0);
+            args.redemptionAmounts[0] = redemption;
+            try feeCalculator.calculateRedemptionFees(address(mockPool), args.tco2s, args.redemptionAmounts) returns (
                 FeeDistribution memory feeDistribution
             ) {
-                feeFromDividedRedemptions += feeDistribution.shares.sumOf();
-                total -= redemption;
-                current -= redemption;
-                mockPool.setTotalSupply(total);
-                setProjectSupply(address(mockToken), current);
+                args.feeFromDividedRedemptions += feeDistribution.shares.sumOf();
+                args.total -= redemption;
+                args.current -= redemption;
+                mockPool.setTotalSupply(args.total);
+                setProjectSupply(address(mockToken), args.current);
             } catch Error(string memory reason) {
-                multipleTimesRedemptionFailedCount++;
+                args.multipleTimesRedemptionFailedCount++;
                 assertTrue(
                     keccak256(bytes("Fee must be lower or equal to requested amount")) == keccak256(bytes(reason)),
                     "error should be 'Fee must be lower or equal to requested amount'"
@@ -125,7 +147,7 @@ contract FeeCalculatorTCO2TestFuzzy is AbstractFeeCalculatorTestFuzzy {
         }
 
         // @dev we allow for 0.1% error
-        assertGe(1001 * feeFromDividedRedemptions / 1000, oneTimeFee);
+        assertGe(1001 * args.feeFromDividedRedemptions / 1000, args.oneTimeFee);
     }
 
     function testCalculateDepositFeesFuzzy_DepositDividedIntoMultipleChunksFeesGreaterOrEqualToOneDeposit(


### PR DESCRIPTION
Leverage memory to avoid stack too deep errors
in tests that have forced us so far to compile
and test with --via-ir that significantly slows
down compilation times.